### PR TITLE
Download & Install OQS using PowerShell

### DIFF
--- a/Download.ps1
+++ b/Download.ps1
@@ -1,4 +1,15 @@
-﻿$path = "$HOME\Documents\OpenQueryStore"
+﻿<#
+.SYNOPSIS
+Download OpenQueryStore from GitHub repository
+
+.DESCRIPTION
+Download OQS to a temporary folder from GitHub repository.
+Unblock the zip file.
+Unzip it
+Move output to Documents\OpenQueryStore folder
+
+#>
+$path = "$HOME\Documents\OpenQueryStore"
 
 $url = 'https://github.com/OpenQueryStore/OpenQueryStore/archive/master.zip'
 $branch = "master"

--- a/Download.ps1
+++ b/Download.ps1
@@ -1,0 +1,57 @@
+﻿$path = "$HOME\Documents\OpenQueryStore"
+
+$url = 'https://github.com/OpenQueryStore/OpenQueryStore/archive/master.zip'
+$branch = "master"
+
+$temp = ([System.IO.Path]::GetTempPath()).TrimEnd("\")
+$zipfile = "$temp\OpenQueryStore.zip"
+
+if (!(Test-Path -Path $path)) {
+	try {
+		Write-Output "Creating directory: $path"
+		New-Item -Path $path -ItemType Directory | Out-Null
+	}
+	catch {
+		throw "Can't create $Path. You may need to Run as Administrator"
+	}
+}
+else {
+	try {
+		Write-Output "Deleting previously installed module"
+		Remove-Item -Path "$path\*" -Force -Recurse
+	}
+	catch {
+		throw "Can't delete $Path. You may need to Run as Administrator"
+	}
+}
+
+Write-Output "Downloading archive from github"
+try {
+	Invoke-WebRequest $url -OutFile $zipfile
+}
+catch {
+	#try with default proxy and usersettings
+	Write-Output "Probably using a proxy for internet access, trying default proxy settings"
+	(New-Object System.Net.WebClient).Proxy.Credentials = [System.Net.CredentialCache]::DefaultNetworkCredentials
+	Invoke-WebRequest $url -OutFile $zipfile
+}
+
+# Unblock if there's a block
+Unblock-File $zipfile -ErrorAction SilentlyContinue
+
+Write-Output "Unzipping"
+
+# Keep it backwards compatible
+$shell = New-Object -ComObject Shell.Application
+$zipPackage = $shell.NameSpace($zipfile)
+$destinationFolder = $shell.NameSpace($temp)
+$destinationFolder.CopyHere($zipPackage.Items())
+
+Write-Output "Cleaning up"
+Move-Item -Path "$temp\OpenQueryStore-$branch\*" $path
+Remove-Item -Path "$temp\OpenQueryStore-$branch"
+Remove-Item -Path $zipfile
+
+
+#Change sesison location so we can run the Install.ps1
+Set-Location $path

--- a/Install.ps1
+++ b/Install.ps1
@@ -1,4 +1,56 @@
-﻿[CmdletBinding()]
+﻿<#
+.SYNOPSIS
+Install OpenQueryStore on specified instance/database
+
+.DESCRIPTION
+Verify if OQS is not already installed on destination database and if not will run the scripts to install it.
+
+.PARAMETER SqlInstance
+The SQL Server that you're connecting to.
+
+.PARAMETER Database
+Specifies the Database where OQS objects will be created
+
+.PARAMETER InstallationType
+Specifies the type of installation to be done. Classic (by default) or Centralised (will be available soon)
+
+.PARAMETER CertificateBackupPath
+Specifies the path where certificate backup will be saved. By default "C:\temp"
+
+.NOTES
+Author: Cláudio Silva (@ClaudioESSilva)
+
+Copyright:
+William Durkin (@sql_williamd) / Enrico van de Laar (@evdlaar)
+
+License:
+	This script is free to download and use for personal, educational, and internal
+	corporate purposes, provided that this header is preserved. Redistribution or sale
+	of this script, in whole or in part, is prohibited without the author's express
+	written consent.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+	OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+.LINK
+https://github.com/OpenQueryStore/OpenQueryStore
+
+.EXAMPLE
+.\Install.ps1 -SqlInstance SQL2012 -Database ScooterStore -InstallationType Classic
+
+Will install the Classic version on instance SQL2012 database named ScooterStore.
+
+.EXAMPLE
+.\Install.ps1 -SqlInstance "SQL2012" -Database "db3" -InstallationType Classic -CertificateBackupPath "C:\temp"
+
+Will install the Classic version on instance SQL2012 database named ScooterStore and use the folder "C:\temp" to save certificate backup.
+
+#>
+[CmdletBinding()]
 param (
 	[string]$SqlInstance,
 	[string]$Database,

--- a/Install.ps1
+++ b/Install.ps1
@@ -1,0 +1,114 @@
+﻿[CmdletBinding()]
+param (
+	[string]$SqlInstance,
+	[string]$Database,
+    [ValidateSet("Classic", "Centralised")]
+	[string]$InstallationType = "Classic",
+    [string]$CertificateBackupPath = "C:\temp"
+)
+
+$path = "$HOME\Documents\OpenQueryStore"
+$qOQSExists = "SELECT TOP 1 1 FROM [$Database].[sys].[schemas] WHERE [name] = 'oqs'"
+
+try {
+    #Connect to instance
+    $instance = New-Object Microsoft.SqlServer.Management.Smo.Server $SqlInstance
+
+    #As is today, we only support between SQL Server 2008 (v10.X.X) and SQL Server 2014 (v12.X.X)
+    if ($instance.Version.Major -lt 10 -or $instance.Version.Major -gt 12) {
+        Write-Warning "We only support instances from SQL Server 2008 (v9.X.X) to SQL Server 2014 (v12.X.X). Your instance version is $($instance.Version). Quitting"
+        return
+    }
+
+    #Verify if database exist in the instance
+    if (-not ($instance.Databases | Where-Object Name -eq $Database)) {
+        Write-Error "Database $Database does not exists on instance $SqlInstance"
+        return
+    }
+
+    #Verify if oqs schema exists
+    $AlreadyExists = $instance.ConnectionContext.ExecuteScalar($qOQSExists)
+
+    #if 'qos' schema already exists - We assume that OQS is already installed
+    if ($AlreadyExists -eq $true) {
+        Write-Warning "OpenQueryStore is already installed on database $database. If you want to reinstall please run the Unistall.sql and then re-run this installer. Quitting."
+        return
+    }
+    else {
+        Write-Output "We will install OQS on database $database"
+    }
+
+    switch ($InstallationType) {
+        "Classic" {
+                    $qInstallOQSClassic = Get-Content -Path "$path\InstallOQSClassic.sql" -Raw
+                    $qInstallOQSServiceBrokerCertificate = Get-Content -Path "$path\InstallOQSServiceBrokerCertificate.sql" -Raw
+                    $qInstallOQSClassicStartupProcedure = Get-Content -Path "$path\InstallOQSClassicStartupProcedure.sql" -Raw
+
+                    #Replace some values
+                    $qInstallOQSClassic = $qInstallOQSClassic -replace "{DatabaseWhereOQSIsRunning}", "[$Database]"
+
+                    $qInstallOQSServiceBrokerCertificate = $qInstallOQSServiceBrokerCertificate -replace "{DatabaseWhereOQSIsRunning}", "[$Database]"
+                    $qInstallOQSServiceBrokerCertificate = $qInstallOQSServiceBrokerCertificate -replace "Enter A File Location accessible by the SQL Server Service Account", "$CertificateBackupPath"
+
+                    $qInstallOQSClassicStartupProcedure = $qInstallOQSClassicStartupProcedure -replace "{DatabaseWhereOQSIsRunning}", "[$Database]"
+
+                    Write-Output "Running InstallOQSClassic.sql"
+                    $null = $instance.ConnectionContext.ExecuteNonQuery($qInstallOQSClassic)
+
+                    #We only need to run this script if we don't have any certificate already created (the same certificate can support multiple databases)
+                    if ($srv.Databases["master"].Certificates | Where-Object Name -eq 'OpenQueryStore') {
+                        Write-Verbose "OpenQueryStore certificate already exists"
+                    }
+                    else {
+                        Write-Output "Running InstallOQSServiceBrokerCertificate.sql"
+                        $null = $instance.ConnectionContext.ExecuteNonQuery($qInstallOQSServiceBrokerCertificate)
+                    }
+
+                    Write-Output "Running InstallOQSClassicStartupProcedure.sql"
+                    $null = $instance.ConnectionContext.ExecuteNonQuery($qInstallOQSClassicStartupProcedure)
+                }
+
+        "Centralised" {
+                    Write-Output "This installation type is not available yet."
+                }
+    }
+
+    #Copy rdl to $mydocuments\SQL Server Management Studio\Custom Reports
+    $customReportsPath = "$home\SQL Server Management Studio\Custom Reports"
+    $null = New-Item -Path $customReportsPath -Force
+
+    Write-Output "Copying custom report (OpenQueryStoreDashboard.rdl) to $customReportsPath"
+
+    $null = Copy-Item -Path "$path\OpenQueryStoreDashboard.rdl" -Destination $customReportsPath -ErrorAction SilentlyContinue
+
+    if (Test-Path -Path "$path\OpenQueryStoreDashboard.rdl") {
+        Write-Output "OpenQueryStoreDashboard.rdl copied with success! You need to go to SSMS and import the report by using - Right click on database -> Reports -> Custom Reports"
+    }
+    else {
+        Write-Output "Unable to copy report to path $customReportsPath"
+    }
+
+    #Ask if user want to start collecting data
+    Write-Output "Installation complete!"
+
+    $title = "Start collecting data"
+    $message = "Do you want to start collecting data for database '$Database'? (Y/N)"
+    $yes = New-Object System.Management.Automation.Host.ChoiceDescription "&Yes", "Start collecting"
+    $no = New-Object System.Management.Automation.Host.ChoiceDescription "&No", "continue"
+    $options = [System.Management.Automation.Host.ChoiceDescription[]]($yes, $no)
+    $result = $host.ui.PromptForChoice($title, $message, $options, 0)
+    #no
+    if ($result -eq 1) {
+	    Write-Warning "You have decided not to start collecting data. To start collecting data you need to run the following instruction manually 'EXECUTE [master].[dbo].[OpenQueryStoreStartup]'."
+    }
+    else {
+        $null = $instance.ConnectionContext.ExecuteNonQuery("EXECUTE [master].[dbo].[OpenQueryStoreStartup]")
+
+        Write-Output "OpenQueryStore started collecting data"
+    }
+}
+catch {
+    Write-Error $_.Exception.Message
+}
+
+$instance.ConnectionContext.Disconnect()

--- a/Install.ps1
+++ b/Install.ps1
@@ -52,7 +52,9 @@ Will install the Classic version on instance SQL2012 database named ScooterStore
 #>
 [CmdletBinding()]
 param (
+    [parameter(Mandatory = $true)]
 	[string]$SqlInstance,
+    [parameter(Mandatory = $true)]
 	[string]$Database,
     [ValidateSet("Classic", "Centralised")]
 	[string]$InstallationType = "Classic",

--- a/InstallOQSClassic.sql
+++ b/InstallOQSClassic.sql
@@ -8,21 +8,22 @@ William Durkin (@sql_williamd) / Enrico van de Laar (@evdlaar)
 
 https://github.com/OpenQueryStore/OpenQueryStore
 
-License: 
-	This script is free to download and use for personal, educational, and internal 
-	corporate purposes, provided that this header is preserved. Redistribution or sale 
-	of this script, in whole or in part, is prohibited without the author's express 
+License:
+	This script is free to download and use for personal, educational, and internal
+	corporate purposes, provided that this header is preserved. Redistribution or sale
+	of this script, in whole or in part, is prohibited without the author's express
 	written consent.
 
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, 
-	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES 
-	OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, 
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+	INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+	OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 **********************************************************************************************/
-
+USE {DatabaseWhereOQSIsRunning}
+GO
 
 SET ANSI_NULLS ON;
 GO
@@ -109,7 +110,7 @@ WITH STATUS = ON,
                  EXECUTE AS OWNER);
 GO
 
--- This is a stored procedure to initiate the Service Broker loop, it can be called manually, or added as a 
+-- This is a stored procedure to initiate the Service Broker loop, it can be called manually, or added as a
 -- startup procedure to ensure data collection when SQL Server starts up
 CREATE PROCEDURE [oqs].[StartScheduler]
 AS
@@ -133,7 +134,7 @@ BEGIN
 END;
 GO
 
--- This is a stored procedure to (temporarilly) stop OQS data collection 
+-- This is a stored procedure to (temporarilly) stop OQS data collection
 CREATE PROCEDURE [oqs].[StopScheduler]
 AS
 BEGIN

--- a/UninstallOQSClassic.sql
+++ b/UninstallOQSClassic.sql
@@ -126,9 +126,20 @@ BEGIN
     DROP CERTIFICATE [OpenQueryStore];
 END;
 
-IF EXISTS (   SELECT * 
-                FROM [sys].[schemas] AS [S] 
+IF EXISTS (   SELECT *
+                FROM [sys].[schemas] AS [S]
                WHERE [S].[name] = 'oqs')
 BEGIN
     EXEC ('DROP SCHEMA oqs');
+END;
+
+
+USE [master]
+GO
+
+IF EXISTS (   SELECT *
+                FROM [sys].[procedures] AS [P]
+               WHERE [P].[object_id] = OBJECT_ID(N'[dbo].[OpenQueryStoreStartup]'))
+BEGIN
+    DROP PROC [dbo].[OpenQueryStoreStartup];
 END;


### PR DESCRIPTION
- Script that will download from GitHub repository
- Script that use downloaded content and install on a specific
instance/database
- Added USE statement on InstallOQSClassic.sql
- Remove dbo.OpenQueryStorestartup stored procedure from master on
UnistallOQSClassic.sql

The idea is to run something like this:
```
Invoke-Expression (Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/OpenQueryStore/OpenQueryStore/master/Download.ps1)
.\Install.ps1 -SqlInstance SQL2012 -Database ScooterShop -InstallationType Classic -CertificateBackupPath "C:\temp"
```

How it works:
 - Download.ps1
   People just need to open PowerShell console and paste
`Invoke-Expression (Invoke-WebRequest -UseBasicParsing https://raw.githubusercontent.com/OpenQueryStore/OpenQueryStore/master/Download.ps1)`

Then the Install
 - Install.ps1
1. You need to specify the SqlInstance and Database
2. Will use smo object to check:
      -> instance version (should be from 2008 through 2014) 
      -> if database existence
      -> if OQS is already installed (check if oqs schema exists on database)

3. Install OQS by running the scripts.
      -> Verify if `OpenQueryStore` certificate already exists. If not will run `InstallOQSServiceBrokerCertificate.sql` script.

4. Copy OpenQueryStoreDashboard.rdl to "...Documents\SQL Server Management Studio\Custom Reports" and say that we need to import manually using SSMS.

5. After installation complete ask if we want to start collecting data if yes, will run `EXECUTE [master].[dbo].[OpenQueryStoreStartup]`

Notes:
 - Only support Classic installation
 - Only support Windows Authentication
