### PR TITLE
Fix bug at installation process

### DIFF
--- a/setup/install_service_broker.sql
+++ b/setup/install_service_broker.sql
@@ -165,7 +165,7 @@ AS
     -- The procedure is called at every SQL Server startup
     BEGIN
         SET NOCOUNT ON;
-        EXEC {DatabaseWhereOQSIsRunning}.[oqs].[start_scheduler];
+        EXEC [{DatabaseWhereOQSIsRunning}].[oqs].[start_scheduler];
     END;
 GO
 

--- a/setup/install_service_broker.sql
+++ b/setup/install_service_broker.sql
@@ -38,7 +38,7 @@ GO
 -- Enable the Service Broker for the user database
 DECLARE @db sysname;
 
-SET @db = DB_NAME();
+SET @db = QUOTENAME(DB_NAME());
 
 IF  (   SELECT [is_broker_enabled]
         FROM   [sys].[databases]

--- a/setup/uninstall_open_query_store.sql
+++ b/setup/uninstall_open_query_store.sql
@@ -194,6 +194,14 @@ IF EXISTS (   SELECT *
     END;
 
 IF EXISTS (   SELECT *
+              FROM   [sys].[views] AS [V]
+              WHERE  [V].[object_id] = OBJECT_ID( N'[oqs].[object_catalog]' )
+          )
+    BEGIN
+        DROP VIEW [oqs].[object_catalog];
+    END;    
+
+IF EXISTS (   SELECT *
               FROM   [sys].[server_principals] AS [SP]
               WHERE  [SP].[name] = 'open_query_store'
           )


### PR DESCRIPTION
I tried to install OQS into a database with a middle hyphen in the name like 'database-DEV' and if kept failing due to the fact that on  script "install_service_broker.sql" on line 168 the brackets were missing. Added the brackets and the problem was solved. Also noticed that while it failed the uninstall script also had a missing drop statement for the view "oqs.object_catalog" and it also failed to uninstall. I fixed that script also to consider the missing drop view sentence.