### PR TITLE
Check for startup procedure in setup\install_service_broker.sql

### DIFF
--- a/Dashboards/OpenQueryStoreDashboard.rdl
+++ b/Dashboards/OpenQueryStoreDashboard.rdl
@@ -154,13 +154,11 @@ ORDER BY TimeDate;</CommandText>
     <DataSet Name="QS_Storage_Size">
       <Query>
         <DataSourceName>LocalServer</DataSourceName>
-        <CommandText>SELECT OBJECT_NAME(object_id) AS 'Table' ,
-       ( reserved_page_count * 8 ) AS 'Size'
-FROM   sys.dm_db_partition_stats
-WHERE  OBJECT_NAME(object_id) IN ( 'Intervals', 'PlanDBID', 'Plans' ,
-                                   'Queries' ,'Query_Runtime_Stats' ,
-                                   'Wait_Stats' ,'Activity_Log','excluded_queries'
-                                 );</CommandText>
+        <CommandText>SELECT 
+	[object_name] AS [Table],
+	[space_used_kb] AS [Size]
+FROM oqs.object_catalog 
+WHERE space_used_kb IS NOT NULL;</CommandText>
         <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
       </Query>
       <Fields>

--- a/Install.ps1
+++ b/Install.ps1
@@ -26,6 +26,9 @@ SQL Login for Agent Job Job Owner - Will default to sa if not specified
 .PARAMETER CreateDatabase
 Create a central OQS database if it isn't already there - Will default to "no" if not specified 
 
+.PARAMETER AutoConfigure
+Automatically sets up data collection, escecially useful in classic mode to quickly start OQS data collection. Defaults to "No".
+
 .NOTES
 Author: Cláudio Silva (@ClaudioESSilva)
         William Durkin (@sql_williamd)
@@ -76,12 +79,16 @@ param (
     [string]$JobOwner = "sa",
     [ValidateSet("Yes", "No")]
     [string]$CreateDatabase = "No"
+    [ValidateSet("Yes", "No")]
+    [string]$AutoConfigure = "No"
 )
 BEGIN {
     $OQSUninstalled = $false
     $path = Get-Location
     $qOQSExists = "SELECT TOP 1 1 FROM [$Database].[sys].[schemas] WHERE [name] = 'oqs'"
     $qOQSCreate = "CREATE DATABASE [$Database]"
+    $qOQSAutoConfigCollection = "UPDATE [oqs].[collection_metadata] SET [collection_active] = 1"
+    $qOQSAutoConfigDatabaseClassic = "INSERT INTO [oqs].[monitored_databases] ( [database_name] ) VALUES ( '$Database' );"
     $CertificateBackupFullPath = Join-Path -Path $CertificateBackupPath  -ChildPath "open_query_store.cer"
     if ($pscmdlet.ShouldProcess("SQL Server SMO", "Loading Assemblies")) {
         try {
@@ -288,8 +295,8 @@ PROCESS {
     # Ready to install! 
     Write-Verbose "Installing OQS ($OQSMode & $SchedulerType) on $SqlInstance in $database"
     
-     # Create OQS database
-     if ($pscmdlet.ShouldProcess("$SqlInstance - $Database", "Creating database if not already available.")) {
+    # Create OQS database
+    if ($pscmdlet.ShouldProcess("$SqlInstance - $Database", "Creating database if not already available.")) {
         try {
             
             Write-Verbose "Creating OQS database [$Database]"
@@ -367,6 +374,33 @@ PROCESS {
             Write-Output "OQS SQL Agent installation completed successfully. A SQL Agent job has been created WITHOUT a schedule. Please create a schedule to begin data collection."
         }
     }
+
+    # Automatic configuration to get OQS up and running *immediately*
+    if ($AutoConfigure -eq "Yes") {
+        Write-Verbose "Autoconfiguring OQS data collection"
+        if ($pscmdlet.ShouldProcess("$SqlInstance - $Database", "Autoconfiguring OQS data collection")) {
+            try {
+                $null = $instance.ConnectionContext.ExecuteNonQuery($qOQSAutoConfigCollection)
+            }
+            catch {
+                Invoke-Catch -Message "Failed to automagically configure OQS data collection, please configure manually"
+            }
+        }
+    }
+
+    # Automatic configuration for classic mode & SQL Agent scheduler type = register the OQS database immediately
+    # Service Broker actually constantly re-registers the database when running in classic mode, making this step less important
+    if (($AutoConfigure -eq "Yes") -and ($SchedulerType -eq "SQL Agent") -and ($OQSMode -eq "Classic") ) {
+        Write-Verbose "Autoconfiguring OQS data collection"
+        if ($pscmdlet.ShouldProcess("$SqlInstance - $Database", "Autoconfiguring OQS data collection: Classic Mode & SQL Agent Scheduler Type")) {
+            try {
+                $null = $instance.ConnectionContext.ExecuteNonQuery($qOQSAutoConfigCollection)
+            }
+            catch {
+                Invoke-Catch -Message "Failed to automagically register [$Database] for $OQSMode and $SchedulerType, please configure manually"
+            }
+        }
+    }
 }
 END {
     if ($pscmdlet.ShouldProcess("$SqlInstance", "Disconnect from ")) {
@@ -379,15 +413,17 @@ END {
     if ($OQSMode -eq "centralized") {
         Write-Output "Centralized mode requires databases to be registered for OQS to monitor them. Please add the database names into the table oqs.monitored_databases." 
     }
-    Write-Output ""
-    Write-Output ""
-    Write-Output "USER ACTION REQUIRED:"
-    Write-Output ""
-    Write-Output "To avoid data collection causing resource issues, OQS data capture is deactivated."
-    Write-Output "Please update the value in column 'collection_active' in table oqs.collection_metadata."
-    Write-Output "UPDATE [oqs].[collection_metadata] SET [collection_active] = 1" 
-    Write-Output ""
-    
+
+    if ($AutoConfigure -eq "No") {
+        Write-Output ""
+        Write-Output ""
+        Write-Output "USER ACTION REQUIRED:"
+        Write-Output ""
+        Write-Output "To avoid data collection causing resource issues, OQS data capture is deactivated."
+        Write-Output "Please update the value in column 'collection_active' in table oqs.collection_metadata."
+        Write-Output "UPDATE [oqs].[collection_metadata] SET [collection_active] = 1" 
+        Write-Output ""
+    }
     if ($SchedulerType -eq "Service Broker") {
         if ($pscmdlet.ShouldProcess("$CertificateBackupFullPath", "Removing OQS Service Broker Certificate file ")) {
             if (Test-Path $CertificateBackupFullPath -PathType Leaf) {

--- a/Install.ps1
+++ b/Install.ps1
@@ -78,7 +78,7 @@ param (
     [string]$CertificateBackupPath = $ENV:TEMP,
     [string]$JobOwner = "sa",
     [ValidateSet("Yes", "No")]
-    [string]$CreateDatabase = "No"
+    [string]$CreateDatabase = "No",
     [ValidateSet("Yes", "No")]
     [string]$AutoConfigure = "No"
 )
@@ -394,7 +394,7 @@ PROCESS {
         Write-Verbose "Autoconfiguring OQS data collection"
         if ($pscmdlet.ShouldProcess("$SqlInstance - $Database", "Autoconfiguring OQS data collection: Classic Mode & SQL Agent Scheduler Type")) {
             try {
-                $null = $instance.ConnectionContext.ExecuteNonQuery($qOQSAutoConfigCollection)
+                $null = $instance.ConnectionContext.ExecuteNonQuery($qOQSAutoConfigDatabaseClassic)
             }
             catch {
                 Invoke-Catch -Message "Failed to automagically register [$Database] for $OQSMode and $SchedulerType, please configure manually"

--- a/setup/install_gather_statistics.sql
+++ b/setup/install_gather_statistics.sql
@@ -55,522 +55,499 @@ AS
         FROM   [oqs].[collection_metadata];
 
         -- Data collection must be activated for us to actually collect data
-        IF  ( SELECT [collection_active] FROM [oqs].[collection_metadata] ) = 1
+        IF ( SELECT [collection_active] FROM [oqs].[collection_metadata] ) = 1
             BEGIN
-
-                IF @logmode = 1
+                -- If we have no databases to monitor, we can skip doing anything!
+                IF ( SELECT COUNT( * ) FROM [oqs].[monitored_databases] AS [MD] ) = 0
                     BEGIN
                         SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
-                                                FROM   [oqs].[activity_log] AS [AL]
-                                            );
+                                                FROM   [oqs].[activity_log] AS [AL] );
+
+
+                        INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                           [log_timestamp],
+                                                           [log_message] )
+                        VALUES ( @log_logrunid, GETDATE(), 'No databases are registered for monitoring' );
                     END;
-
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script started...' );
-                    END;
-
-                -- Create a new interval
-                INSERT INTO [oqs].[intervals] ( [interval_start] ) VALUES ( GETDATE());
-
-                -- Setup the execution_threshold. If we have no setting, we default to 2 to avoid single use plans
-                SELECT @execution_threshold = [execution_threshold]
-                FROM   [oqs].[collection_metadata];
-
-                IF @execution_threshold IS NULL SET @execution_threshold = 2;
-
-
-                IF OBJECT_ID('tempdb..#plan_dbid') IS NOT NULL
-                    DROP TABLE #plan_dbid;
-					
-				CREATE TABLE #plan_dbid (
-					plan_handle varbinary(64) NOT NULL,
-					dbid int NOT NULL,
-					PRIMARY KEY CLUSTERED (plan_handle, dbid)
-				)
-
-				-- We capture plans based on databases that are present in the Databases table of the OpenQueryStore database				
-				-- First, everythihng does into a temp table (we'll need this data for the next query)	
-                INSERT INTO #plan_dbid (   [plan_handle],
-                                           [dbid]
-                                       )
-                            SELECT   [plan_handle],
-                                     CONVERT( int, [pvt].[dbid] )
-                            FROM     (   SELECT [plan_handle],
-                                                [epa].[attribute],
-                                                [epa].[value]
-                                         FROM   [sys].[dm_exec_cached_plans]
-                                                OUTER APPLY [sys].[dm_exec_plan_attributes]( [plan_handle] ) AS [epa]
-                                         WHERE  [cacheobjtype] = 'Compiled Plan'
-                                                AND [usecounts] >= @execution_threshold
-                                     ) AS [ecpa]
-                            PIVOT (   MAX([value])
-                                      FOR [attribute] IN ( "dbid", "sql_handle" )
-                                  ) AS [pvt]
-                            WHERE    [plan_handle] NOT IN ( SELECT [PD].[plan_handle] FROM [oqs].[plan_dbid] AS [PD] )
-                                     AND [pvt].[dbid] IN (   SELECT DB_ID( [MD].[database_name] )
-                                                             FROM   [oqs].[monitored_databases] AS [MD]
-                                                         )
-                            ORDER BY [pvt].[sql_handle];
-
-                -- Next, we add the rows to the destination table
-                INSERT INTO [oqs].[plan_dbid] (   [plan_handle] ,
-                                                  [dbid]
-                                              )
-                            SELECT [plan_handle], [dbid]
-                            FROM #plan_dbid;
-
-                -- Start execution plan insertion
-                -- Get plans from the plan cache that do not exist in the OQS_Plans table
-                -- for the database on the current context
-                INSERT INTO [oqs].[plans] (   [plan_MD5],
-                                              [plan_handle],
-                                              [plan_firstfound],
-                                              [plan_database],
-                                              [plan_refcounts],
-                                              [plan_usecounts],
-                                              [plan_sizeinbytes],
-                                              [plan_type],
-                                              [plan_objecttype],
-                                              [plan_executionplan]
-                                          )
-                            SELECT (qs.query_hash+qs.query_plan_hash),
-                                   [cp].[plan_handle],
-                                   GETDATE(),
-                                   DB_NAME( [pd].[dbid] ),
-                                   [cp].[refcounts],
-                                   [cp].[usecounts],
-                                   [cp].[size_in_bytes],
-                                   [cp].[cacheobjtype],
-                                   [cp].[objtype],
-                                   [qp].[query_plan]
-                            FROM   [oqs].[plan_dbid] AS [pd]
-							       INNER MERGE JOIN #plan_dbid AS tpdb ON [tpdb].[plan_handle] = [pd].[plan_handle] AND [tpdb].[dbid] = [pd].[dbid]
-                                   INNER HASH JOIN [sys].[dm_exec_cached_plans] AS [cp] ON [pd].[plan_handle] = [cp].[plan_handle]
-                                   CROSS APPLY [sys].[dm_exec_query_plan]( [cp].[plan_handle] ) AS [qp]
-                                   INNER JOIN sys.dm_exec_query_stats AS [qs] ON [pd].[plan_handle] = [qs].[plan_handle]
-                            WHERE  [cp].[cacheobjtype] = 'Compiled Plan'
-                                   AND ( [qp].[query_plan] IS NOT NULL )
-                                   AND (qs.query_hash+qs.query_plan_hash) NOT IN ( SELECT [plan_MD5] FROM [oqs].[plans] );
-
-                SET @log_newplans = @@RowCount;
-
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newplans ) + ' new plan(s)...' );
-                    END
-
-				-- Now that the plans are stored on disk we are going to retrieve additional plan information
-				-- from the XML plan
-				;WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-				UPDATE oqs.plans
-				SET plan_optimization = p2.Optimization_level, xml_processed = 1
-				FROM
-					(
-					SELECT
-						p.plan_id,
-						CASE
-						  WHEN Exec_Plans.Plans.value( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar') = 'T' THEN 'Trivial'
-						  WHEN Exec_Plans.Plans.value( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar') = 'F' THEN 'Full'
-						  END AS 'Optimization_level'		
-					FROM oqs.plans p
-					CROSS APPLY plan_executionplan.nodes('.') AS Exec_Plans(Plans)
-					) AS p2
-				WHERE oqs.plans.plan_id = p2.plan_id AND oqs.plans.xml_processed = 0
-
-                -- Grab all of the queries (statement level) that are connected to the plans inside the OQS
-                ;
-                WITH [CTE_Queries] ( [plan_id], [plan_handle], [plan_MD5] )
-                AS ( SELECT [plan_id], [plan_handle], [plan_MD5] FROM [oqs].[plans] )
-                INSERT INTO [oqs].[queries] (   [plan_id],
-                                                [query_hash],
-                                                [query_plan_MD5],
-                                                [query_statement_text],
-                                                [query_statement_start_offset],
-                                                [query_statement_end_offset],
-                                                [query_creation_time]
-                                            )
-                            SELECT [cte].[plan_id],
-                                   [qs].[query_hash],
-                                   ( [cte].[plan_MD5] + [qs].[query_hash] ) AS [Query_plan_MD5],
-                                   SUBSTRING(   [st].[text], ( [qs].[statement_start_offset] / 2 ) + 1, (( CASE [qs].[statement_end_offset]
-                                                                                                                WHEN-1 THEN DATALENGTH( [st].[text] )
-                                                                                                                ELSE [qs].[statement_end_offset]
-                                                                                                           END - [qs].[statement_start_offset]
-                                                                                                         ) / 2
-                                                                                                        ) + 1
-                                            )                               AS [statement_text],
-                                   [qs].[statement_start_offset],
-                                   [qs].[statement_end_offset],
-                                   [qs].[creation_time]
-                            FROM   [CTE_Queries] AS [cte]
-                                   INNER JOIN [oqs].[query_stats] AS [qs] ON [cte].[plan_handle] = [qs].[plan_handle]
-                                   CROSS APPLY [sys].[dm_exec_sql_text]( [qs].[sql_handle] ) AS [st]
-                            WHERE  ( [cte].[plan_MD5] + [qs].[query_hash] ) NOT IN ( SELECT [Query_plan_MD5] FROM [oqs].[queries] );
-
-                SET @log_newqueries = @@RowCount;
-
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newqueries ) + ' new queries...' );
-                    END;
-
-					-- Remove all the queries that are related to OQS plans
-					;WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-					DELETE FROM oqs.queries
-					WHERE plan_id IN (
-						SELECT
-							plan_id	
-						FROM oqs.plans p
-						CROSS APPLY plan_executionplan.nodes('.') AS Exec_Plans(Plans)
-						WHERE Exec_Plans.Plans.[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 )
-
-					-- Remove all the plans that are related to OQS plans
-					;WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-					DELETE FROM oqs.plans
-					WHERE plan_id IN (
-						SELECT
-							plan_id	
-						FROM oqs.plans p
-						CROSS APPLY plan_executionplan.nodes('.') AS Exec_Plans(Plans)
-						WHERE Exec_Plans.Plans.[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 )
-
-
-                -- Grab the interval_id of the interval we added at the beginning
-                DECLARE @Interval_ID int;
-                SET @Interval_ID = IDENT_CURRENT( '[oqs].[intervals]' );
-
-                -- Query Runtime Snapshot
-
-                -- Insert runtime statistics for every query statement that is recorded inside the OQS
-                INSERT INTO [oqs].[query_runtime_stats] (   [query_id],
-                                                            [interval_id],
-                                                            [creation_time],
-                                                            [last_execution_time],
-                                                            [execution_count],
-                                                            [total_elapsed_time],
-                                                            [last_elapsed_time],
-                                                            [min_elapsed_time],
-                                                            [max_elapsed_time],
-                                                            [avg_elapsed_time],
-                                                            [total_rows],
-                                                            [last_rows],
-                                                            [min_rows],
-                                                            [max_rows],
-                                                            [avg_rows],
-                                                            [total_worker_time],
-                                                            [last_worker_time],
-                                                            [min_worker_time],
-                                                            [max_worker_time],
-                                                            [avg_worker_time],
-                                                            [total_physical_reads],
-                                                            [last_physical_reads],
-                                                            [min_physical_reads],
-                                                            [max_physical_reads],
-                                                            [avg_physical_reads],
-                                                            [total_logical_reads],
-                                                            [last_logical_reads],
-                                                            [min_logical_reads],
-                                                            [max_logical_reads],
-                                                            [avg_logical_reads],
-                                                            [total_logical_writes],
-                                                            [last_logical_writes],
-                                                            [min_logical_writes],
-                                                            [max_logical_writes],
-                                                            [avg_logical_writes]
-                                                        )
-                            SELECT [oqs_q].[query_id],
-                                   @Interval_ID,
-                                   [qs].[creation_time],
-                                   [qs].[last_execution_time],
-                                   [qs].[execution_count],
-                                   [qs].[total_elapsed_time],
-                                   [qs].[last_elapsed_time],
-                                   [qs].[min_elapsed_time],
-                                   [qs].[max_elapsed_time],
-                                   0,
-                                   [qs].[total_rows],
-                                   [qs].[last_rows],
-                                   [qs].[min_rows],
-                                   [qs].[max_rows],
-                                   0,
-                                   [qs].[total_worker_time],
-                                   [qs].[last_worker_time],
-                                   [qs].[min_worker_time],
-                                   [qs].[max_worker_time],
-                                   0,
-                                   [qs].[total_physical_reads],
-                                   [qs].[last_physical_reads],
-                                   [qs].[min_physical_reads],
-                                   [qs].[max_physical_reads],
-                                   0,
-                                   [qs].[total_logical_reads],
-                                   [qs].[last_logical_reads],
-                                   [qs].[min_logical_reads],
-                                   [qs].[max_logical_reads],
-                                   0,
-                                   [qs].[total_logical_writes],
-                                   [qs].[last_logical_writes],
-                                   [qs].[min_logical_writes],
-                                   [qs].[max_logical_writes],
-                                   0
-                            FROM   [oqs].[queries] AS [oqs_q]
-                                   INNER JOIN [oqs].[query_stats] AS [qs] ON (   [oqs_q].[query_hash] = [qs].[query_hash]
-                                                                                 AND [oqs_q].[query_statement_start_offset] = [qs].[statement_start_offset]
-                                                                                 AND [oqs_q].[query_statement_end_offset] = [qs].[statement_end_offset]
-                                                                                 AND [oqs_q].[query_creation_time] = [qs].[creation_time]
-                                                                             );
-
-                -- DEBUG: Get current info of the QRS table
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of captured runtime statistics';
-                        SELECT * FROM [oqs].[query_runtime_stats] AS [QRS];
-                    END;
-
-                -- Wait stats snapshot
-                INSERT INTO [oqs].[wait_stats] (   [interval_id],
-                                                   [wait_type],
-                                                   [waiting_tasks_count],
-                                                   [wait_time_ms],
-                                                   [max_wait_time_ms],
-                                                   [signal_wait_time_ms]
-                                               )
-                            SELECT @Interval_ID,
-                                   [wait_type],
-                                   [waiting_tasks_count],
-                                   [wait_time_ms],
-                                   [max_wait_time_ms],
-                                   [signal_wait_time_ms]
-                            FROM   [sys].[dm_os_wait_stats]
-                            WHERE  (   [waiting_tasks_count] > 0
-                                       AND [wait_time_ms] > 0
-                                   );
-
-                -- DEBUG: Get current info of the wait stats table
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of wait stats';
-                        SELECT * FROM [oqs].[wait_stats] AS [WS];
-                    END;
-
-                -- Close the previous interval now that the statistics are updated
-                UPDATE [oqs].[intervals]
-                SET    [interval_end] = GETDATE()
-                WHERE  [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] );
-
-                -- Now that we have the runtime statistics inside the OQS we need to perform some calculations
-                -- so we can see query performance per interval captured
-
-                -- First thing we need is a temporary table to hold our calculated deltas
-                IF OBJECT_ID( 'tempdb..#OQS_Runtime_Stats' ) IS NOT NULL
-                    BEGIN
-                        DROP TABLE [#OQS_Runtime_Stats];
-                    END;
-
-                IF OBJECT_ID( 'tempdb..#OQS_Wait_Stats' ) IS NOT NULL
-                    BEGIN
-                        DROP TABLE [#OQS_Wait_Stats];
-                    END
-
-                -- Calculate Deltas for Runtime stats
-                ;
-                WITH [CTE_Update_Runtime_Stats] ( [query_id], [interval_id], [execution_count], [total_elapsed_time], [total_rows], [total_worker_time], [total_physical_reads], [total_logical_reads], [total_logical_writes] )
-                AS ( SELECT [QRS].[query_id],
-                            [QRS].[interval_id],
-                            [QRS].[execution_count],
-                            [QRS].[total_elapsed_time],
-                            [QRS].[total_rows],
-                            [QRS].[total_worker_time],
-                            [QRS].[total_physical_reads],
-                            [QRS].[total_logical_reads],
-                            [QRS].[total_logical_writes]
-                     FROM   [oqs].[query_runtime_stats] AS [QRS]
-                     WHERE  [QRS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] )
-                   )
-                SELECT [cte].[query_id],
-                       [cte].[interval_id],
-                       ( [qrs].[execution_count] - [cte].[execution_count] )                                                                                            AS [Delta Exec Count],
-                       ( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] )                                                                                      AS [Delta Time],
-                       ISNULL((( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )     AS [Avg. Time],
-                       ( [qrs].[total_rows] - [cte].[total_rows] )                                                                                                      AS [Delta Total Rows],
-                       ISNULL((( [qrs].[total_rows] - [cte].[total_rows] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )                     AS [Avg. Rows],
-                       ( [qrs].[total_worker_time] - [cte].[total_worker_time] )                                                                                        AS [Delta Total Worker Time],
-                       ISNULL((( [qrs].[total_worker_time] - [cte].[total_worker_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )       AS [Avg. Worker Time],
-                       ( [qrs].[total_physical_reads] - [cte].[total_physical_reads] )                                                                                  AS [Delta Total Phys Reads],
-                       ISNULL((( [qrs].[total_physical_reads] - [cte].[total_physical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Phys reads],
-                       ( [qrs].[total_logical_reads] - [cte].[total_logical_reads] )                                                                                    AS [Delta Total Log Reads],
-                       ISNULL((( [qrs].[total_logical_reads] - [cte].[total_logical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )   AS [Avg. Log reads],
-                       ( [qrs].[total_logical_writes] - [cte].[total_logical_writes] )                                                                                  AS [Delta Total Log Writes],
-                       ISNULL((( [qrs].[total_logical_writes] - [cte].[total_logical_writes] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Log writes]
-                INTO   [#OQS_Runtime_Stats]
-                FROM   [CTE_Update_Runtime_Stats] AS [cte]
-                       INNER JOIN [oqs].[query_runtime_stats] AS [qrs] ON [cte].[query_id] = [qrs].[query_id]
-                WHERE  [qrs].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
-
-                SET @log_runtime_stats = @@RowCount;
-
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_runtime_stats ) + ' runtime statistics...' );
-                    END;
-
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of runtime statistics deltas';
-                        SELECT * FROM [#OQS_Runtime_Stats];
-                    END;
-
-                -- Update the runtime statistics of the queries captured in the previous interval
-                -- with the delta runtime information
-                UPDATE [qrs]
-                SET    [qrs].[execution_count] = [tqrs].[Delta Exec Count],
-                       [qrs].[total_elapsed_time] = [tqrs].[Delta Time],
-                       [qrs].[avg_elapsed_time] = [tqrs].[Avg. Time],
-                       [qrs].[total_rows] = [tqrs].[Delta Total Rows],
-                       [qrs].[avg_rows] = [tqrs].[Avg. Rows],
-                       [qrs].[total_worker_time] = [tqrs].[Delta Total Worker Time],
-                       [qrs].[avg_worker_time] = [tqrs].[Avg. Worker Time],
-                       [qrs].[total_physical_reads] = [tqrs].[Delta Total Phys Reads],
-                       [qrs].[avg_physical_reads] = [tqrs].[Avg. Phys reads],
-                       [qrs].[total_logical_reads] = [tqrs].[Delta Total Log Reads],
-                       [qrs].[avg_logical_reads] = [tqrs].[Avg. Log reads],
-                       [qrs].[total_logical_writes] = [tqrs].[Delta Total Log Writes],
-                       [qrs].[avg_logical_writes] = [tqrs].[Avg. Log writes]
-                FROM   [oqs].[query_runtime_stats] AS [qrs]
-                       INNER JOIN [#OQS_Runtime_Stats] AS [tqrs] ON (   [qrs].[interval_id] = [tqrs].[interval_id]
-                                                                        AND [qrs].[query_id] = [tqrs].[query_id]
-                                                                    );
-
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of runtime statistics after delta update';
-                        SELECT * FROM [oqs].[query_runtime_stats] AS [qrs];
-                    END;
-
-                    -- Calculate Deltas for Wait stats
-                ;
-                WITH [CTE_Update_wait_Stats] ( [interval_id], [wait_type], [waiting_tasks_count], [wait_time_ms], [max_wait_time_ms], [signal_wait_time_ms] )
-                    AS ( SELECT [WS].[interval_id],
-                                [WS].[wait_type],
-                                [WS].[waiting_tasks_count],
-                                [WS].[wait_time_ms],
-                                [WS].[max_wait_time_ms],
-                                [WS].[signal_wait_time_ms]
-                         FROM   [oqs].[wait_stats] AS [WS]
-                         WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] )
-                       )
-                SELECT [cte].[wait_type],
-                       [cte].[interval_id],
-                       ( [WS].[waiting_tasks_count] - [cte].[waiting_tasks_count] ) AS [Delta Waiting Tasks Count],
-                       ( [WS].[wait_time_ms] - [cte].[wait_time_ms] )               AS [Delta Wait Time ms],
-                       ( [WS].[max_wait_time_ms] - [cte].[max_wait_time_ms] )       AS [Delta Max Wait Time ms],
-                       ( [WS].[signal_wait_time_ms] - [cte].[signal_wait_time_ms] ) AS [Delta Signal Wait Time ms]
-                INTO   [#OQS_Wait_Stats]
-                FROM   [CTE_Update_wait_Stats] AS [cte]
-                       INNER JOIN [oqs].[wait_stats] AS [WS] ON [cte].[wait_type] = [WS].[wait_type]
-                WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
-
-                SET @log_wait_stats = @@RowCount;
-
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_wait_stats ) + ' wait statistics...' );
-                    END;
-
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of wait stats deltas';
-                        SELECT * FROM [#OQS_Wait_Stats];
-                    END;
-
-                -- Update the runtime statistics of the queries captured in the previous interval
-                -- with the delta runtime information
-                UPDATE [WS]
-                SET    [WS].[waiting_tasks_count] = [tws].[Delta Waiting Tasks Count],
-                       [WS].[wait_time_ms] = [Delta Wait Time ms],
-                       [WS].[max_wait_time_ms] = [Delta Max Wait Time ms],
-                       [WS].[signal_wait_time_ms] = [Delta Signal Wait Time ms]
-                FROM   [oqs].[wait_stats] AS [WS]
-                       INNER JOIN [#OQS_Wait_Stats] AS [tws] ON (   [WS].[interval_id] = [tws].[interval_id]
-                                                                    AND [WS].[wait_type] = [tws].[wait_type]
-                                                                );
-
-                IF @debug = 1
-                    BEGIN
-                        SELECT 'Snapshot of runtime statistics after delta update';
-                        SELECT * FROM [oqs].[wait_stats] AS [WS];
-                    END;
-
-                -- Remove the wait stats delta's where 0 waits occured
-                DELETE FROM [oqs].[wait_stats]
-                WHERE (   [waiting_tasks_count] = 0
-                          AND [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] )
-                      );
-
-                -- Run regular OQS store cleanup if activated
-                IF @data_cleanup_active = 1
+                ELSE
+                    -- Monitoring is active *and* we have at least one database to process. Let's get to work
                     BEGIN
                         IF @logmode = 1
                             BEGIN
-                                INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                                     [log_timestamp],
-                                                                     [log_message]
-                                                                 )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
+                                SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
+                                                        FROM   [oqs].[activity_log] AS [AL] );
                             END;
 
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script started...' );
+                            END;
 
-                        EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
-                                                  @data_cleanup_throttle = @data_cleanup_throttle;
+                        -- Create a new interval
+                        INSERT INTO [oqs].[intervals] ( [interval_start] ) VALUES ( GETDATE());
 
-                    END;
+                        -- Setup the execution_threshold. If we have no setting, we default to 2 to avoid single use plans
+                        SELECT @execution_threshold = [execution_threshold]
+                        FROM   [oqs].[collection_metadata];
+
+                        IF @execution_threshold IS NULL SET @execution_threshold = 2;
 
 
-                -- And we are done!
-                IF @logmode = 1
-                    BEGIN
-                        INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                             [log_timestamp],
-                                                             [log_message]
-                                                         )
-                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script finished...' );
+                        IF OBJECT_ID( 'tempdb..#plan_dbid' ) IS NOT NULL DROP TABLE [#plan_dbid];
+
+                        CREATE TABLE [#plan_dbid]
+                            (
+                                [plan_handle] varbinary (64) NOT NULL,
+                                [dbid]        int            NOT NULL,
+                                PRIMARY KEY CLUSTERED ( [plan_handle], [dbid] )
+                            );
+
+                        -- We capture plans based on databases that are present in the monitored_databases table of the OpenQueryStore database				
+                        -- First, everything goes into a temp table (we'll need this data for the next query)	
+                        INSERT INTO [#plan_dbid] ( [plan_handle],
+                                                   [dbid] )
+                                    SELECT   [plan_handle],
+                                             CONVERT( int, [pvt].[dbid] )
+                                    FROM     (   SELECT [plan_handle],
+                                                        [epa].[attribute],
+                                                        [epa].[value]
+                                                 FROM   [sys].[dm_exec_cached_plans]
+                                                        OUTER APPLY [sys].[dm_exec_plan_attributes]( [plan_handle] ) AS [epa]
+                                                 WHERE  [cacheobjtype] = 'Compiled Plan'
+                                                        AND [usecounts] >= @execution_threshold ) AS [ecpa]
+                                    PIVOT (   MAX([value])
+                                              FOR [attribute] IN ( "dbid", "sql_handle" )) AS [pvt]
+                                    WHERE    [plan_handle] NOT IN ( SELECT [PD].[plan_handle] FROM [oqs].[plan_dbid] AS [PD] )
+                                             AND [pvt].[dbid] IN (   SELECT DB_ID( [MD].[database_name] )
+                                                                     FROM   [oqs].[monitored_databases] AS [MD] )
+                                    ORDER BY [pvt].[sql_handle];
+
+                        -- Next, we add the rows to the destination table
+                        INSERT INTO [oqs].[plan_dbid] ( [plan_handle],
+                                                        [dbid] )
+                                    SELECT [plan_handle], [dbid] FROM [#plan_dbid];
+
+                        -- Start execution plan insertion
+                        -- Get plans from the plan cache that do not exist in the OQS_Plans table
+                        -- for the database on the current context
+                        INSERT INTO [oqs].[plans] ( [plan_MD5],
+                                                    [plan_handle],
+                                                    [plan_firstfound],
+                                                    [plan_database],
+                                                    [plan_refcounts],
+                                                    [plan_usecounts],
+                                                    [plan_sizeinbytes],
+                                                    [plan_type],
+                                                    [plan_objecttype],
+                                                    [plan_executionplan] )
+                                    SELECT ( [qs].[query_hash] + [qs].[query_plan_hash] ),
+                                           [cp].[plan_handle],
+                                           GETDATE(),
+                                           DB_NAME( [pd].[dbid] ),
+                                           [cp].[refcounts],
+                                           [cp].[usecounts],
+                                           [cp].[size_in_bytes],
+                                           [cp].[cacheobjtype],
+                                           [cp].[objtype],
+                                           [qp].[query_plan]
+                                    FROM   [oqs].[plan_dbid]                                            AS [pd]
+                                           INNER MERGE JOIN [#plan_dbid]                                AS [tpdb] ON [tpdb].[plan_handle] = [pd].[plan_handle]
+                                                                                                                     AND [tpdb].[dbid] = [pd].[dbid]
+                                           INNER HASH JOIN [sys].[dm_exec_cached_plans]                 AS [cp] ON [pd].[plan_handle] = [cp].[plan_handle]
+                                           CROSS APPLY [sys].[dm_exec_query_plan]( [cp].[plan_handle] ) AS [qp]
+                                           INNER JOIN [sys].[dm_exec_query_stats] AS [qs] ON [pd].[plan_handle] = [qs].[plan_handle]
+                                    WHERE  [cp].[cacheobjtype] = 'Compiled Plan'
+                                           AND ( [qp].[query_plan] IS NOT NULL )
+                                           AND ( [qs].[query_hash] + [qs].[query_plan_hash] ) NOT IN ( SELECT [plan_MD5] FROM [oqs].[plans] );
+
+                        SET @log_newplans = @@RowCount;
+
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newplans ) + ' new plan(s)...' );
+                            END
+
+                            -- Now that the plans are stored on disk we are going to retrieve additional plan information
+                            -- from the XML plan
+                            ;
+                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                        UPDATE [oqs].[plans]
+                        SET    [plan_optimization] = [p2].[Optimization_level],
+                               [xml_processed] = 1
+                        FROM   (   SELECT [p].[plan_id],
+                                          CASE WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'T' THEN 'Trivial'
+                                               WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'F' THEN 'Full'
+                                          END AS [Optimization_level]
+                                   FROM   [oqs].[plans]                                   AS [p]
+                                          CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans]) ) AS [p2]
+                        WHERE  [plans].[plan_id] = [p2].[plan_id]
+                               AND [xml_processed] = 0
+
+                        -- Grab all of the queries (statement level) that are connected to the plans inside the OQS
+                        ;
+                        WITH [CTE_Queries] ( [plan_id], [plan_handle], [plan_MD5] )
+                        AS ( SELECT [plan_id], [plan_handle], [plan_MD5] FROM [oqs].[plans] )
+                        INSERT INTO [oqs].[queries] ( [plan_id],
+                                                      [query_hash],
+                                                      [query_plan_MD5],
+                                                      [query_statement_text],
+                                                      [query_statement_start_offset],
+                                                      [query_statement_end_offset],
+                                                      [query_creation_time] )
+                                    SELECT [cte].[plan_id],
+                                           [qs].[query_hash],
+                                           ( [cte].[plan_MD5] + [qs].[query_hash] )                                                                                AS [Query_plan_MD5],
+                                           SUBSTRING( [st].[text], ( [qs].[statement_start_offset] / 2 ) + 1, (( CASE [qs].[statement_end_offset]
+                                                                                                                      WHEN-1 THEN DATALENGTH( [st].[text] )
+                                                                                                                      ELSE [qs].[statement_end_offset]
+                                                                                                                 END - [qs].[statement_start_offset] ) / 2 ) + 1 ) AS [statement_text],
+                                           [qs].[statement_start_offset],
+                                           [qs].[statement_end_offset],
+                                           [qs].[creation_time]
+                                    FROM   [CTE_Queries]                                             AS [cte]
+                                           INNER JOIN [oqs].[query_stats]                            AS [qs] ON [cte].[plan_handle] = [qs].[plan_handle]
+                                           CROSS APPLY [sys].[dm_exec_sql_text]( [qs].[sql_handle] ) AS [st]
+                                    WHERE  ( [cte].[plan_MD5] + [qs].[query_hash] ) NOT IN ( SELECT [query_plan_MD5] FROM [oqs].[queries] );
+
+                        SET @log_newqueries = @@RowCount;
+
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newqueries ) + ' new queries...' );
+                            END;
+
+                        -- Remove all the queries that are related to OQS plans
+                        ;
+                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                        DELETE FROM [oqs].[queries]
+                        WHERE [plan_id] IN (   SELECT [p].[plan_id]
+                                               FROM   [oqs].[plans]                                   AS [p]
+                                                      CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
+                                               WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 )
+
+                        -- Remove all the plans that are related to OQS plans
+                        ;
+                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                        DELETE FROM [oqs].[plans]
+                        WHERE [plan_id] IN (   SELECT [p].[plan_id]
+                                               FROM   [oqs].[plans]                                   AS [p]
+                                                      CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
+                                               WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 );
+
+
+                        -- Grab the interval_id of the interval we added at the beginning
+                        DECLARE @Interval_ID int;
+                        SET @Interval_ID = IDENT_CURRENT( '[oqs].[intervals]' );
+
+                        -- Query Runtime Snapshot
+
+                        -- Insert runtime statistics for every query statement that is recorded inside the OQS
+                        INSERT INTO [oqs].[query_runtime_stats] ( [query_id],
+                                                                  [interval_id],
+                                                                  [creation_time],
+                                                                  [last_execution_time],
+                                                                  [execution_count],
+                                                                  [total_elapsed_time],
+                                                                  [last_elapsed_time],
+                                                                  [min_elapsed_time],
+                                                                  [max_elapsed_time],
+                                                                  [avg_elapsed_time],
+                                                                  [total_rows],
+                                                                  [last_rows],
+                                                                  [min_rows],
+                                                                  [max_rows],
+                                                                  [avg_rows],
+                                                                  [total_worker_time],
+                                                                  [last_worker_time],
+                                                                  [min_worker_time],
+                                                                  [max_worker_time],
+                                                                  [avg_worker_time],
+                                                                  [total_physical_reads],
+                                                                  [last_physical_reads],
+                                                                  [min_physical_reads],
+                                                                  [max_physical_reads],
+                                                                  [avg_physical_reads],
+                                                                  [total_logical_reads],
+                                                                  [last_logical_reads],
+                                                                  [min_logical_reads],
+                                                                  [max_logical_reads],
+                                                                  [avg_logical_reads],
+                                                                  [total_logical_writes],
+                                                                  [last_logical_writes],
+                                                                  [min_logical_writes],
+                                                                  [max_logical_writes],
+                                                                  [avg_logical_writes] )
+                                    SELECT [oqs_q].[query_id],
+                                           @Interval_ID,
+                                           [qs].[creation_time],
+                                           [qs].[last_execution_time],
+                                           [qs].[execution_count],
+                                           [qs].[total_elapsed_time],
+                                           [qs].[last_elapsed_time],
+                                           [qs].[min_elapsed_time],
+                                           [qs].[max_elapsed_time],
+                                           0,
+                                           [qs].[total_rows],
+                                           [qs].[last_rows],
+                                           [qs].[min_rows],
+                                           [qs].[max_rows],
+                                           0,
+                                           [qs].[total_worker_time],
+                                           [qs].[last_worker_time],
+                                           [qs].[min_worker_time],
+                                           [qs].[max_worker_time],
+                                           0,
+                                           [qs].[total_physical_reads],
+                                           [qs].[last_physical_reads],
+                                           [qs].[min_physical_reads],
+                                           [qs].[max_physical_reads],
+                                           0,
+                                           [qs].[total_logical_reads],
+                                           [qs].[last_logical_reads],
+                                           [qs].[min_logical_reads],
+                                           [qs].[max_logical_reads],
+                                           0,
+                                           [qs].[total_logical_writes],
+                                           [qs].[last_logical_writes],
+                                           [qs].[min_logical_writes],
+                                           [qs].[max_logical_writes],
+                                           0
+                                    FROM   [oqs].[queries]                AS [oqs_q]
+                                           INNER JOIN [oqs].[query_stats] AS [qs] ON (   [oqs_q].[query_hash] = [qs].[query_hash]
+                                                                                         AND [oqs_q].[query_statement_start_offset] = [qs].[statement_start_offset]
+                                                                                         AND [oqs_q].[query_statement_end_offset] = [qs].[statement_end_offset]
+                                                                                         AND [oqs_q].[query_creation_time] = [qs].[creation_time] );
+
+                        -- DEBUG: Get current info of the QRS table
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of captured runtime statistics';
+                                SELECT * FROM [oqs].[query_runtime_stats] AS [QRS];
+                            END;
+
+                        -- Wait stats snapshot
+                        INSERT INTO [oqs].[wait_stats] ( [interval_id],
+                                                         [wait_type],
+                                                         [waiting_tasks_count],
+                                                         [wait_time_ms],
+                                                         [max_wait_time_ms],
+                                                         [signal_wait_time_ms] )
+                                    SELECT @Interval_ID,
+                                           [wait_type],
+                                           [waiting_tasks_count],
+                                           [wait_time_ms],
+                                           [max_wait_time_ms],
+                                           [signal_wait_time_ms]
+                                    FROM   [sys].[dm_os_wait_stats]
+                                    WHERE  (   [waiting_tasks_count] > 0
+                                               AND [wait_time_ms] > 0 );
+
+                        -- DEBUG: Get current info of the wait stats table
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of wait stats';
+                                SELECT * FROM [oqs].[wait_stats] AS [WS];
+                            END;
+
+                        -- Close the previous interval now that the statistics are updated
+                        UPDATE [oqs].[intervals]
+                        SET    [interval_end] = GETDATE()
+                        WHERE  [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] );
+
+                        -- Now that we have the runtime statistics inside the OQS we need to perform some calculations
+                        -- so we can see query performance per interval captured
+
+                        -- First thing we need is a temporary table to hold our calculated deltas
+                        IF OBJECT_ID( 'tempdb..#OQS_Runtime_Stats' ) IS NOT NULL
+                            BEGIN
+                                DROP TABLE [#OQS_Runtime_Stats];
+                            END;
+
+                        IF OBJECT_ID( 'tempdb..#OQS_Wait_Stats' ) IS NOT NULL
+                            BEGIN
+                                DROP TABLE [#OQS_Wait_Stats];
+                            END
+
+                            -- Calculate Deltas for Runtime stats
+                            ;
+                        WITH [CTE_Update_Runtime_Stats] ( [query_id], [interval_id], [execution_count], [total_elapsed_time], [total_rows], [total_worker_time], [total_physical_reads], [total_logical_reads], [total_logical_writes] )
+                        AS ( SELECT [QRS].[query_id],
+                                    [QRS].[interval_id],
+                                    [QRS].[execution_count],
+                                    [QRS].[total_elapsed_time],
+                                    [QRS].[total_rows],
+                                    [QRS].[total_worker_time],
+                                    [QRS].[total_physical_reads],
+                                    [QRS].[total_logical_reads],
+                                    [QRS].[total_logical_writes]
+                             FROM   [oqs].[query_runtime_stats] AS [QRS]
+                             WHERE  [QRS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
+                        SELECT [cte].[query_id],
+                               [cte].[interval_id],
+                               ( [qrs].[execution_count] - [cte].[execution_count] )                                                                                            AS [Delta Exec Count],
+                               ( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] )                                                                                      AS [Delta Time],
+                               ISNULL((( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )     AS [Avg. Time],
+                               ( [qrs].[total_rows] - [cte].[total_rows] )                                                                                                      AS [Delta Total Rows],
+                               ISNULL((( [qrs].[total_rows] - [cte].[total_rows] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )                     AS [Avg. Rows],
+                               ( [qrs].[total_worker_time] - [cte].[total_worker_time] )                                                                                        AS [Delta Total Worker Time],
+                               ISNULL((( [qrs].[total_worker_time] - [cte].[total_worker_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )       AS [Avg. Worker Time],
+                               ( [qrs].[total_physical_reads] - [cte].[total_physical_reads] )                                                                                  AS [Delta Total Phys Reads],
+                               ISNULL((( [qrs].[total_physical_reads] - [cte].[total_physical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Phys reads],
+                               ( [qrs].[total_logical_reads] - [cte].[total_logical_reads] )                                                                                    AS [Delta Total Log Reads],
+                               ISNULL((( [qrs].[total_logical_reads] - [cte].[total_logical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )   AS [Avg. Log reads],
+                               ( [qrs].[total_logical_writes] - [cte].[total_logical_writes] )                                                                                  AS [Delta Total Log Writes],
+                               ISNULL((( [qrs].[total_logical_writes] - [cte].[total_logical_writes] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Log writes]
+                        INTO   [#OQS_Runtime_Stats]
+                        FROM   [CTE_Update_Runtime_Stats]             AS [cte]
+                               INNER JOIN [oqs].[query_runtime_stats] AS [qrs] ON [cte].[query_id] = [qrs].[query_id]
+                        WHERE  [qrs].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
+
+                        SET @log_runtime_stats = @@RowCount;
+
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_runtime_stats ) + ' runtime statistics...' );
+                            END;
+
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of runtime statistics deltas';
+                                SELECT * FROM [#OQS_Runtime_Stats];
+                            END;
+
+                        -- Update the runtime statistics of the queries captured in the previous interval
+                        -- with the delta runtime information
+                        UPDATE [qrs]
+                        SET    [qrs].[execution_count] = [tqrs].[Delta Exec Count],
+                               [qrs].[total_elapsed_time] = [tqrs].[Delta Time],
+                               [qrs].[avg_elapsed_time] = [tqrs].[Avg. Time],
+                               [qrs].[total_rows] = [tqrs].[Delta Total Rows],
+                               [qrs].[avg_rows] = [tqrs].[Avg. Rows],
+                               [qrs].[total_worker_time] = [tqrs].[Delta Total Worker Time],
+                               [qrs].[avg_worker_time] = [tqrs].[Avg. Worker Time],
+                               [qrs].[total_physical_reads] = [tqrs].[Delta Total Phys Reads],
+                               [qrs].[avg_physical_reads] = [tqrs].[Avg. Phys reads],
+                               [qrs].[total_logical_reads] = [tqrs].[Delta Total Log Reads],
+                               [qrs].[avg_logical_reads] = [tqrs].[Avg. Log reads],
+                               [qrs].[total_logical_writes] = [tqrs].[Delta Total Log Writes],
+                               [qrs].[avg_logical_writes] = [tqrs].[Avg. Log writes]
+                        FROM   [oqs].[query_runtime_stats]     AS [qrs]
+                               INNER JOIN [#OQS_Runtime_Stats] AS [tqrs] ON (   [qrs].[interval_id] = [tqrs].[interval_id]
+                                                                                AND [qrs].[query_id] = [tqrs].[query_id] );
+
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of runtime statistics after delta update';
+                                SELECT * FROM [oqs].[query_runtime_stats] AS [qrs];
+                            END;
+
+                            -- Calculate Deltas for Wait stats
+						;
+                        WITH [CTE_Update_wait_Stats] ( [interval_id], [wait_type], [waiting_tasks_count], [wait_time_ms], [max_wait_time_ms], [signal_wait_time_ms] )
+                            AS ( SELECT [WS].[interval_id],
+                                        [WS].[wait_type],
+                                        [WS].[waiting_tasks_count],
+                                        [WS].[wait_time_ms],
+                                        [WS].[max_wait_time_ms],
+                                        [WS].[signal_wait_time_ms]
+                                 FROM   [oqs].[wait_stats] AS [WS]
+                                 WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
+                        SELECT [cte].[wait_type],
+                               [cte].[interval_id],
+                               ( [WS].[waiting_tasks_count] - [cte].[waiting_tasks_count] ) AS [Delta Waiting Tasks Count],
+                               ( [WS].[wait_time_ms] - [cte].[wait_time_ms] )               AS [Delta Wait Time ms],
+                               ( [WS].[max_wait_time_ms] - [cte].[max_wait_time_ms] )       AS [Delta Max Wait Time ms],
+                               ( [WS].[signal_wait_time_ms] - [cte].[signal_wait_time_ms] ) AS [Delta Signal Wait Time ms]
+                        INTO   [#OQS_Wait_Stats]
+                        FROM   [CTE_Update_wait_Stats]       AS [cte]
+                               INNER JOIN [oqs].[wait_stats] AS [WS] ON [cte].[wait_type] = [WS].[wait_type]
+                        WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
+
+                        SET @log_wait_stats = @@RowCount;
+
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_wait_stats ) + ' wait statistics...' );
+                            END;
+
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of wait stats deltas';
+                                SELECT * FROM [#OQS_Wait_Stats];
+                            END;
+
+                        -- Update the runtime statistics of the queries captured in the previous interval
+                        -- with the delta runtime information
+                        UPDATE [WS]
+                        SET    [WS].[waiting_tasks_count] = [tws].[Delta Waiting Tasks Count],
+                               [WS].[wait_time_ms] = [Delta Wait Time ms],
+                               [WS].[max_wait_time_ms] = [Delta Max Wait Time ms],
+                               [WS].[signal_wait_time_ms] = [Delta Signal Wait Time ms]
+                        FROM   [oqs].[wait_stats]           AS [WS]
+                               INNER JOIN [#OQS_Wait_Stats] AS [tws] ON (   [WS].[interval_id] = [tws].[interval_id]
+                                                                            AND [WS].[wait_type] = [tws].[wait_type] );
+
+                        IF @debug = 1
+                            BEGIN
+                                SELECT 'Snapshot of runtime statistics after delta update';
+                                SELECT * FROM [oqs].[wait_stats] AS [WS];
+                            END;
+
+                        -- Remove the wait stats delta's where 0 waits occured
+                        DELETE FROM [oqs].[wait_stats]
+                        WHERE (   [waiting_tasks_count] = 0
+                                  AND [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ));
+
+                        -- Run regular OQS store cleanup if activated
+                        IF @data_cleanup_active = 1
+                            BEGIN
+                                IF @logmode = 1
+                                    BEGIN
+                                        INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                           [log_timestamp],
+                                                                           [log_message] )
+                                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
+                                    END;
+
+								-- Tidy up time!
+                                EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
+                                                          @data_cleanup_throttle = @data_cleanup_throttle;
+
+                            END;
+
+                        -- And we are done!
+                        IF @logmode = 1
+                            BEGIN
+                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                   [log_timestamp],
+                                                                   [log_message] )
+                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script finished...' );
+                            END;
                     END;
             END;
         ELSE
             BEGIN
-                BEGIN
-                    SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
-                                            FROM   [oqs].[activity_log] AS [AL]
-                                        );
+                SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
+                                        FROM   [oqs].[activity_log] AS [AL] );
 
-                    INSERT INTO [oqs].[activity_log] (   [log_run_id],
-                                                         [log_timestamp],
-                                                         [log_message]
-                                                     )
-                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data capture not activated. Collection skipped' );
-                END;
+                INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                   [log_timestamp],
+                                                   [log_message] )
+                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data capture not activated. Collection skipped' );
             END;
     END;
-
-GO

--- a/setup/install_gather_statistics.sql
+++ b/setup/install_gather_statistics.sql
@@ -43,15 +43,19 @@ AS
     DECLARE @log_wait_stats int;
     DECLARE @execution_threshold int;
     DECLARE @collection_active bit;
+	DECLARE @oqs_maximum_size_mb smallint;
     DECLARE @data_cleanup_active bit;
-    DECLARE @data_cleanup_threshold bit;
-    DECLARE @data_cleanup_throttle bit;
+    DECLARE @data_cleanup_threshold tinyint;
+    DECLARE @data_cleanup_throttle smallint;
     BEGIN
 
         SET NOCOUNT ON;
 
         SELECT @collection_active   = [collection_active],
-               @data_cleanup_active = [data_cleanup_active]
+			   @oqs_maximum_size_mb = [oqs_maximum_size_mb],
+               @data_cleanup_active = [data_cleanup_active],
+               @data_cleanup_threshold = [data_cleanup_threshold],
+               @data_cleanup_throttle = [data_cleanup_throttle]
         FROM   [oqs].[collection_metadata];
 
         -- Data collection must be activated for us to actually collect data
@@ -70,134 +74,76 @@ AS
                         VALUES ( @log_logrunid, GETDATE(), 'No databases are registered for monitoring' );
                     END;
                 ELSE
-                    -- Monitoring is active *and* we have at least one database to process. Let's get to work
+                -- We can only collect data if the maximum configured size is higher than the space currently used by OQS
+                IF (@oqs_maximum_size_mb*1024 > (SELECT SUM(space_used_kb) FROM oqs.object_catalog))
                     BEGIN
-                        IF @logmode = 1
-                            BEGIN
-                                SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
-                                                        FROM   [oqs].[activity_log] AS [AL] );
-                            END;
+                        -- Monitoring is active *and* we have at least one database to process. Let's get to work
+                        BEGIN
+                            IF @logmode = 1
+                                BEGIN
+                                    SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
+                                                            FROM   [oqs].[activity_log] AS [AL] );
+                                END;
 
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script started...' );
-                            END;
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script started...' );
+                                END;
 
-                        -- Create a new interval
-                        INSERT INTO [oqs].[intervals] ( [interval_start] ) VALUES ( GETDATE());
+                            -- Create a new interval
+                            INSERT INTO [oqs].[intervals] ( [interval_start] ) VALUES ( GETDATE());
 
-                        -- Setup the execution_threshold. If we have no setting, we default to 2 to avoid single use plans
-                        SELECT @execution_threshold = [execution_threshold]
-                        FROM   [oqs].[collection_metadata];
+                            -- Setup the execution_threshold. If we have no setting, we default to 2 to avoid single use plans
+                            SELECT @execution_threshold = [execution_threshold]
+                            FROM   [oqs].[collection_metadata];
 
-                        IF @execution_threshold IS NULL SET @execution_threshold = 2;
+                            IF @execution_threshold IS NULL SET @execution_threshold = 2;
 
 
-                        IF OBJECT_ID( 'tempdb..#plan_dbid' ) IS NOT NULL DROP TABLE [#plan_dbid];
+                            IF OBJECT_ID( 'tempdb..#plan_dbid' ) IS NOT NULL DROP TABLE [#plan_dbid];
 
-                        CREATE TABLE [#plan_dbid]
-                            (
-                                [plan_handle] varbinary (64) NOT NULL,
-                                [dbid]        int            NOT NULL,
-                                PRIMARY KEY CLUSTERED ( [plan_handle], [dbid] )
-                            );
+                            CREATE TABLE [#plan_dbid]
+                                (
+                                    [plan_handle] varbinary (64) NOT NULL,
+                                    [dbid]        int            NOT NULL,
+                                    PRIMARY KEY CLUSTERED ( [plan_handle], [dbid] )
+                                );
 
-                        -- We capture plans based on databases that are present in the monitored_databases table of the OpenQueryStore database				
-                        -- First, everything goes into a temp table (we'll need this data for the next query)	
-                        INSERT INTO [#plan_dbid] ( [plan_handle],
-                                                   [dbid] )
-                                    SELECT   [plan_handle],
-                                             CONVERT( int, [pvt].[dbid] )
-                                    FROM     (   SELECT [plan_handle],
-                                                        [epa].[attribute],
-                                                        [epa].[value]
-                                                 FROM   [sys].[dm_exec_cached_plans]
-                                                        OUTER APPLY [sys].[dm_exec_plan_attributes]( [plan_handle] ) AS [epa]
-                                                 WHERE  [cacheobjtype] = 'Compiled Plan'
-                                                        AND [usecounts] >= @execution_threshold ) AS [ecpa]
-                                    PIVOT (   MAX([value])
-                                              FOR [attribute] IN ( "dbid", "sql_handle" )) AS [pvt]
-                                    WHERE    [plan_handle] NOT IN ( SELECT [PD].[plan_handle] FROM [oqs].[plan_dbid] AS [PD] )
-                                             AND [pvt].[dbid] IN (   SELECT DB_ID( [MD].[database_name] )
-                                                                     FROM   [oqs].[monitored_databases] AS [MD] )
-                                    ORDER BY [pvt].[sql_handle];
+                            -- We capture plans based on databases that are present in the monitored_databases table of the OpenQueryStore database				
+                            -- First, everything goes into a temp table (we'll need this data for the next query)	
+                            INSERT INTO [#plan_dbid] ( [plan_handle],
+                                                       [dbid] )
+                                        SELECT   [plan_handle],
+                                                 CONVERT( int, [pvt].[dbid] )
+                                        FROM     (   SELECT [plan_handle],
+                                                            [epa].[attribute],
+                                                            [epa].[value]
+                                                     FROM   [sys].[dm_exec_cached_plans]
+                                                            OUTER APPLY [sys].[dm_exec_plan_attributes]( [plan_handle] ) AS [epa]
+                                                     WHERE  [cacheobjtype] = 'Compiled Plan'
+                                                            AND [usecounts] >= @execution_threshold ) AS [ecpa]
+                                        PIVOT (   MAX([value])
+                                                  FOR [attribute] IN ( "dbid", "sql_handle" )) AS [pvt]
+                                        WHERE    [plan_handle] NOT IN ( SELECT [PD].[plan_handle] FROM [oqs].[plan_dbid] AS [PD] )
+                                                 AND [pvt].[dbid] IN (   SELECT DB_ID( [MD].[database_name] )
+                                                                         FROM   [oqs].[monitored_databases] AS [MD] )
+                                        ORDER BY [pvt].[sql_handle];
 
-                        -- Next, we add the rows to the destination table
-                        INSERT INTO [oqs].[plan_dbid] ( [plan_handle],
-                                                        [dbid] )
-                                    SELECT [plan_handle], [dbid] FROM [#plan_dbid];
+                            -- Next, we add the rows to the destination table
+                            INSERT INTO [oqs].[plan_dbid] ( [plan_handle],
+                                                            [dbid] )
+                                        SELECT [plan_handle], [dbid] FROM [#plan_dbid];
 
-                        -- Start execution plan insertion
-                        -- Get plans from the plan cache that do not exist in the OQS_Plans table
-                        -- for the database on the current context
-                        IF OBJECT_ID( 'tempdb..#plans' ) IS NOT NULL DROP TABLE [#plans];
+                            -- Start execution plan insertion
+                            -- Get plans from the plan cache that do not exist in the OQS_Plans table
+                            -- for the database on the current context
+                            IF OBJECT_ID( 'tempdb..#plans' ) IS NOT NULL DROP TABLE [#plans];
                         
-                        SELECT TOP(0)
-                            [plan_MD5],
-                            [plan_handle],
-                            [plan_firstfound],
-                            [plan_database],
-                            [plan_refcounts],
-                            [plan_usecounts],
-                            [plan_sizeinbytes],
-                            [plan_type],
-                            [plan_objecttype],
-                            [plan_executionplan]
-                        INTO #plans
-                        FROM [oqs].[plans];
-
-                        INSERT INTO #plans ( [plan_MD5],
-                            [plan_handle],
-                            [plan_firstfound],
-                            [plan_database],
-                            [plan_refcounts],
-                            [plan_usecounts],
-                            [plan_sizeinbytes],
-                            [plan_type],
-                            [plan_objecttype],
-                            [plan_executionplan] )
-                         SELECT 
-                               [plan_MD5],
-                               [plan_handle],
-                               [plan_firstfound],
-                               [plan_database],
-                               [plan_refcounts],
-                               [plan_usecounts],
-                               [plan_sizeinbytes],
-                               [plan_type],
-                               [plan_objecttype],
-                               [qp].[query_plan] AS [plan_executionplan]
-                         FROM (
-                                  SELECT TOP(2147483645) 
-                                           ( [qs].[query_hash] + [qs].[query_plan_hash] ) AS [plan_MD5],
-                                           [cp].[plan_handle],
-                                           GETDATE() AS [plan_firstfound],
-                                           DB_NAME( [pd].[dbid] ) AS [plan_database],
-                                           [cp].[refcounts] AS [plan_refcounts],
-                                           [cp].[usecounts] AS [plan_usecounts],
-                                           [cp].[size_in_bytes] AS [plan_sizeinbytes],
-                                           [cp].[cacheobjtype] AS [plan_type],
-                                           [cp].[objtype] AS [plan_objecttype]
-                                    FROM   [oqs].[plan_dbid]                                            AS [pd]
-                                           INNER HASH JOIN [sys].[dm_exec_cached_plans]                 AS [cp] ON [pd].[plan_handle] = [cp].[plan_handle]
-                                           INNER JOIN [sys].[dm_exec_query_stats] AS [qs] ON [pd].[plan_handle] = [qs].[plan_handle]
-                                    WHERE  [cp].[cacheobjtype] = 'Compiled Plan'
-                                           AND EXISTS (
-                                                SELECT * 
-                                                FROM [#plan_dbid] AS [tpdb] 
-                                                WHERE [tpdb].[plan_handle] = [pd].[plan_handle]
-                                                    AND [tpdb].[dbid] = [pd].[dbid]
-                                            )
-                         ) AS [cp]
-                         CROSS APPLY [sys].[dm_exec_query_plan]( [cp].[plan_handle] ) AS [qp]
-                         WHERE ( [qp].[query_plan] IS NOT NULL );
-
-                                                                    
-                                                                    
-                        INSERT INTO [oqs].[plans] ( [plan_MD5],
+                            SELECT TOP(0)
+                                [plan_MD5],
                                 [plan_handle],
                                 [plan_firstfound],
                                 [plan_database],
@@ -206,388 +152,460 @@ AS
                                 [plan_sizeinbytes],
                                 [plan_type],
                                 [plan_objecttype],
-                                [plan_executionplan] 
-                        )
-                        SELECT * 
-                        FROM #plans
-                        WHERE [plan_MD5] NOT IN (SELECT [plan_MD5] FROM [oqs].[plans]);
+                                [plan_executionplan]
+                            INTO #plans
+                            FROM [oqs].[plans];
 
-                        SET @log_newplans = @@RowCount;
+                            INSERT INTO #plans ( [plan_MD5],
+                                [plan_handle],
+                                [plan_firstfound],
+                                [plan_database],
+                                [plan_refcounts],
+                                [plan_usecounts],
+                                [plan_sizeinbytes],
+                                [plan_type],
+                                [plan_objecttype],
+                                [plan_executionplan] )
+                             SELECT 
+                                   [plan_MD5],
+                                   [plan_handle],
+                                   [plan_firstfound],
+                                   [plan_database],
+                                   [plan_refcounts],
+                                   [plan_usecounts],
+                                   [plan_sizeinbytes],
+                                   [plan_type],
+                                   [plan_objecttype],
+                                   [qp].[query_plan] AS [plan_executionplan]
+                             FROM (
+                                      SELECT TOP(2147483645) 
+                                               ( [qs].[query_hash] + [qs].[query_plan_hash] ) AS [plan_MD5],
+                                               [cp].[plan_handle],
+                                               GETDATE() AS [plan_firstfound],
+                                               DB_NAME( [pd].[dbid] ) AS [plan_database],
+                                               [cp].[refcounts] AS [plan_refcounts],
+                                               [cp].[usecounts] AS [plan_usecounts],
+                                               [cp].[size_in_bytes] AS [plan_sizeinbytes],
+                                               [cp].[cacheobjtype] AS [plan_type],
+                                               [cp].[objtype] AS [plan_objecttype]
+                                        FROM   [oqs].[plan_dbid]                                            AS [pd]
+                                               INNER HASH JOIN [sys].[dm_exec_cached_plans]                 AS [cp] ON [pd].[plan_handle] = [cp].[plan_handle]
+                                               INNER JOIN [sys].[dm_exec_query_stats] AS [qs] ON [pd].[plan_handle] = [qs].[plan_handle]
+                                        WHERE  [cp].[cacheobjtype] = 'Compiled Plan'
+                                               AND EXISTS (
+                                                    SELECT * 
+                                                    FROM [#plan_dbid] AS [tpdb] 
+                                                    WHERE [tpdb].[plan_handle] = [pd].[plan_handle]
+                                                        AND [tpdb].[dbid] = [pd].[dbid]
+                                                )
+                             ) AS [cp]
+                             CROSS APPLY [sys].[dm_exec_query_plan]( [cp].[plan_handle] ) AS [qp]
+                             WHERE ( [qp].[query_plan] IS NOT NULL );
 
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newplans ) + ' new plan(s)...' );
-                            END
+                                                                    
+                                                                    
+                            INSERT INTO [oqs].[plans] ( [plan_MD5],
+                                    [plan_handle],
+                                    [plan_firstfound],
+                                    [plan_database],
+                                    [plan_refcounts],
+                                    [plan_usecounts],
+                                    [plan_sizeinbytes],
+                                    [plan_type],
+                                    [plan_objecttype],
+                                    [plan_executionplan] 
+                            )
+                            SELECT * 
+                            FROM #plans
+                            WHERE [plan_MD5] NOT IN (SELECT [plan_MD5] FROM [oqs].[plans]);
 
-                            -- Now that the plans are stored on disk we are going to retrieve additional plan information
-                            -- from the XML plan
+                            SET @log_newplans = @@RowCount;
+
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newplans ) + ' new plan(s)...' );
+                                END
+
+                                -- Now that the plans are stored on disk we are going to retrieve additional plan information
+                                -- from the XML plan
+                                ;
+                            WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                            UPDATE [oqs].[plans]
+                            SET    [plan_optimization] = [p2].[Optimization_level],
+                                   [xml_processed] = 1
+                            FROM   (   SELECT [p].[plan_id],
+                                              CASE WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'T' THEN 'Trivial'
+                                                   WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'F' THEN 'Full'
+                                              END AS [Optimization_level]
+                                       FROM   [oqs].[plans]                                   AS [p]
+                                              CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans]) ) AS [p2]
+                            WHERE  [plans].[plan_id] = [p2].[plan_id]
+                                   AND [xml_processed] = 0
+
+                            -- Grab all of the queries (statement level) that are connected to the plans inside the OQS
                             ;
-                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-                        UPDATE [oqs].[plans]
-                        SET    [plan_optimization] = [p2].[Optimization_level],
-                               [xml_processed] = 1
-                        FROM   (   SELECT [p].[plan_id],
-                                          CASE WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'T' THEN 'Trivial'
-                                               WHEN [Exec_Plans].[Plans].[value]( '(/ShowPlanXML/BatchSequence/Batch/Statements/StmtSimple/@StatementOptmLevel)[1]', 'varchar' ) = 'F' THEN 'Full'
-                                          END AS [Optimization_level]
-                                   FROM   [oqs].[plans]                                   AS [p]
-                                          CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans]) ) AS [p2]
-                        WHERE  [plans].[plan_id] = [p2].[plan_id]
-                               AND [xml_processed] = 0
+                            WITH [CTE_Queries] ( [plan_id], [plan_handle], [plan_MD5] )
+                            AS ( SELECT [plan_id], [plan_handle], [plan_MD5] FROM [oqs].[plans] )
+                            INSERT INTO [oqs].[queries] ( [plan_id],
+                                                          [query_hash],
+                                                          [query_plan_MD5],
+                                                          [query_statement_text],
+                                                          [query_statement_start_offset],
+                                                          [query_statement_end_offset],
+                                                          [query_creation_time] )
+                                        SELECT [cte].[plan_id],
+                                               [qs].[query_hash],
+                                               ( [cte].[plan_MD5] + [qs].[query_hash] )                                                                                AS [Query_plan_MD5],
+                                               SUBSTRING( [st].[text], ( [qs].[statement_start_offset] / 2 ) + 1, (( CASE [qs].[statement_end_offset]
+                                                                                                                          WHEN-1 THEN DATALENGTH( [st].[text] )
+                                                                                                                          ELSE [qs].[statement_end_offset]
+                                                                                                                     END - [qs].[statement_start_offset] ) / 2 ) + 1 ) AS [statement_text],
+                                               [qs].[statement_start_offset],
+                                               [qs].[statement_end_offset],
+                                               [qs].[creation_time]
+                                        FROM   [CTE_Queries]                                             AS [cte]
+                                               INNER JOIN [oqs].[query_stats]                            AS [qs] ON [cte].[plan_handle] = [qs].[plan_handle]
+                                               CROSS APPLY [sys].[dm_exec_sql_text]( [qs].[sql_handle] ) AS [st]
+                                        WHERE  ( [cte].[plan_MD5] + [qs].[query_hash] ) NOT IN ( SELECT [query_plan_MD5] FROM [oqs].[queries] );
 
-                        -- Grab all of the queries (statement level) that are connected to the plans inside the OQS
-                        ;
-                        WITH [CTE_Queries] ( [plan_id], [plan_handle], [plan_MD5] )
-                        AS ( SELECT [plan_id], [plan_handle], [plan_MD5] FROM [oqs].[plans] )
-                        INSERT INTO [oqs].[queries] ( [plan_id],
-                                                      [query_hash],
-                                                      [query_plan_MD5],
-                                                      [query_statement_text],
-                                                      [query_statement_start_offset],
-                                                      [query_statement_end_offset],
-                                                      [query_creation_time] )
-                                    SELECT [cte].[plan_id],
-                                           [qs].[query_hash],
-                                           ( [cte].[plan_MD5] + [qs].[query_hash] )                                                                                AS [Query_plan_MD5],
-                                           SUBSTRING( [st].[text], ( [qs].[statement_start_offset] / 2 ) + 1, (( CASE [qs].[statement_end_offset]
-                                                                                                                      WHEN-1 THEN DATALENGTH( [st].[text] )
-                                                                                                                      ELSE [qs].[statement_end_offset]
-                                                                                                                 END - [qs].[statement_start_offset] ) / 2 ) + 1 ) AS [statement_text],
-                                           [qs].[statement_start_offset],
-                                           [qs].[statement_end_offset],
-                                           [qs].[creation_time]
-                                    FROM   [CTE_Queries]                                             AS [cte]
-                                           INNER JOIN [oqs].[query_stats]                            AS [qs] ON [cte].[plan_handle] = [qs].[plan_handle]
-                                           CROSS APPLY [sys].[dm_exec_sql_text]( [qs].[sql_handle] ) AS [st]
-                                    WHERE  ( [cte].[plan_MD5] + [qs].[query_hash] ) NOT IN ( SELECT [query_plan_MD5] FROM [oqs].[queries] );
+                            SET @log_newqueries = @@RowCount;
 
-                        SET @log_newqueries = @@RowCount;
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newqueries ) + ' new queries...' );
+                                END;
 
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_newqueries ) + ' new queries...' );
-                            END;
-
-                        -- Remove all the queries that are related to OQS plans
-                        ;
-                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-                        DELETE FROM [oqs].[queries]
-                        WHERE [plan_id] IN (   SELECT [p].[plan_id]
-                                               FROM   [oqs].[plans]                                   AS [p]
-                                                      CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
-                                               WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 )
-
-                        -- Remove all the plans that are related to OQS plans
-                        ;
-                        WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
-                        DELETE FROM [oqs].[plans]
-                        WHERE [plan_id] IN (   SELECT [p].[plan_id]
-                                               FROM   [oqs].[plans]                                   AS [p]
-                                                      CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
-                                               WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 );
-
-
-                        -- Grab the interval_id of the interval we added at the beginning
-                        DECLARE @Interval_ID int;
-                        SET @Interval_ID = IDENT_CURRENT( '[oqs].[intervals]' );
-
-                        -- Query Runtime Snapshot
-
-                        -- Insert runtime statistics for every query statement that is recorded inside the OQS
-                        INSERT INTO [oqs].[query_runtime_stats] ( [query_id],
-                                                                  [interval_id],
-                                                                  [creation_time],
-                                                                  [last_execution_time],
-                                                                  [execution_count],
-                                                                  [total_elapsed_time],
-                                                                  [last_elapsed_time],
-                                                                  [min_elapsed_time],
-                                                                  [max_elapsed_time],
-                                                                  [avg_elapsed_time],
-                                                                  [total_rows],
-                                                                  [last_rows],
-                                                                  [min_rows],
-                                                                  [max_rows],
-                                                                  [avg_rows],
-                                                                  [total_worker_time],
-                                                                  [last_worker_time],
-                                                                  [min_worker_time],
-                                                                  [max_worker_time],
-                                                                  [avg_worker_time],
-                                                                  [total_physical_reads],
-                                                                  [last_physical_reads],
-                                                                  [min_physical_reads],
-                                                                  [max_physical_reads],
-                                                                  [avg_physical_reads],
-                                                                  [total_logical_reads],
-                                                                  [last_logical_reads],
-                                                                  [min_logical_reads],
-                                                                  [max_logical_reads],
-                                                                  [avg_logical_reads],
-                                                                  [total_logical_writes],
-                                                                  [last_logical_writes],
-                                                                  [min_logical_writes],
-                                                                  [max_logical_writes],
-                                                                  [avg_logical_writes] )
-SELECT [oqs_q].[query_id],
-                                           @Interval_ID,
-                                           MIN([qs].[creation_time]),
-                                           MAX([qs].[last_execution_time]),
-                                           SUM([qs].[execution_count]),
-                                           SUM([qs].[total_elapsed_time]),
-                                           SUM([qs].[last_elapsed_time]),
-                                           MIN([qs].[min_elapsed_time]),
-                                           MAX([qs].[max_elapsed_time]),
-                                           0,
-                                           SUM([qs].[total_rows]),
-                                           SUM([qs].[last_rows]),
-                                           MIN([qs].[min_rows]),
-                                           MAX([qs].[max_rows]),
-                                           0,
-                                           SUM([qs].[total_worker_time]),
-                                           SUM([qs].[last_worker_time]),
-                                           MIN([qs].[min_worker_time]),
-                                           MAX([qs].[max_worker_time]),
-                                           0,
-                                           SUM([qs].[total_physical_reads]),
-                                           SUM([qs].[last_physical_reads]),
-                                           MIN([qs].[min_physical_reads]),
-                                           MAX([qs].[max_physical_reads]),
-                                           0,
-                                           SUM([qs].[total_logical_reads]),
-                                           SUM([qs].[last_logical_reads]),
-                                           MIN([qs].[min_logical_reads]),
-                                           MAX([qs].[max_logical_reads]),
-                                           0,
-                                           SUM([qs].[total_logical_writes]),
-                                           SUM([qs].[last_logical_writes]),
-                                           MIN([qs].[min_logical_writes]),
-                                           MAX([qs].[max_logical_writes]),
-                                           0
-                                    FROM   [oqs].[queries]                AS [oqs_q]
-                                           INNER JOIN [oqs].[query_stats] AS [qs] ON (   [oqs_q].[query_hash] = [qs].[query_hash]
-                                                                                         AND [oqs_q].[query_statement_start_offset] = [qs].[statement_start_offset]
-                                                                                         AND [oqs_q].[query_statement_end_offset] = [qs].[statement_end_offset]
-                                                                                         AND [oqs_q].[query_creation_time] = [qs].[creation_time] )
-                                    GROUP BY [oqs_q].[query_id];
-
-                        -- DEBUG: Get current info of the QRS table
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of captured runtime statistics';
-                                SELECT * FROM [oqs].[query_runtime_stats] AS [QRS];
-                            END;
-
-                        -- Wait stats snapshot
-                        INSERT INTO [oqs].[wait_stats] ( [interval_id],
-                                                         [wait_type],
-                                                         [waiting_tasks_count],
-                                                         [wait_time_ms],
-                                                         [max_wait_time_ms],
-                                                         [signal_wait_time_ms] )
-                                    SELECT @Interval_ID,
-                                           [wait_type],
-                                           [waiting_tasks_count],
-                                           [wait_time_ms],
-                                           [max_wait_time_ms],
-                                           [signal_wait_time_ms]
-                                    FROM   [sys].[dm_os_wait_stats]
-                                    WHERE  (   [waiting_tasks_count] > 0
-                                               AND [wait_time_ms] > 0 );
-
-                        -- DEBUG: Get current info of the wait stats table
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of wait stats';
-                                SELECT * FROM [oqs].[wait_stats] AS [WS];
-                            END;
-
-                        -- Close the previous interval now that the statistics are updated
-                        UPDATE [oqs].[intervals]
-                        SET    [interval_end] = GETDATE()
-                        WHERE  [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] );
-
-                        -- Now that we have the runtime statistics inside the OQS we need to perform some calculations
-                        -- so we can see query performance per interval captured
-
-                        -- First thing we need is a temporary table to hold our calculated deltas
-                        IF OBJECT_ID( 'tempdb..#OQS_Runtime_Stats' ) IS NOT NULL
-                            BEGIN
-                                DROP TABLE [#OQS_Runtime_Stats];
-                            END;
-
-                        IF OBJECT_ID( 'tempdb..#OQS_Wait_Stats' ) IS NOT NULL
-                            BEGIN
-                                DROP TABLE [#OQS_Wait_Stats];
-                            END
-
-                            -- Calculate Deltas for Runtime stats
+                            -- Remove all the queries that are related to OQS plans
                             ;
-                        WITH [CTE_Update_Runtime_Stats] ( [query_id], [interval_id], [execution_count], [total_elapsed_time], [total_rows], [total_worker_time], [total_physical_reads], [total_logical_reads], [total_logical_writes] )
-                        AS ( SELECT [QRS].[query_id],
-                                    [QRS].[interval_id],
-                                    [QRS].[execution_count],
-                                    [QRS].[total_elapsed_time],
-                                    [QRS].[total_rows],
-                                    [QRS].[total_worker_time],
-                                    [QRS].[total_physical_reads],
-                                    [QRS].[total_logical_reads],
-                                    [QRS].[total_logical_writes]
-                             FROM   [oqs].[query_runtime_stats] AS [QRS]
-                             WHERE  [QRS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
-                        SELECT [cte].[query_id],
-                               [cte].[interval_id],
-                               ( [qrs].[execution_count] - [cte].[execution_count] )                                                                                            AS [Delta Exec Count],
-                               ( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] )                                                                                      AS [Delta Time],
-                               ISNULL((( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )     AS [Avg. Time],
-                               ( [qrs].[total_rows] - [cte].[total_rows] )                                                                                                      AS [Delta Total Rows],
-                               ISNULL((( [qrs].[total_rows] - [cte].[total_rows] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )                     AS [Avg. Rows],
-                               ( [qrs].[total_worker_time] - [cte].[total_worker_time] )                                                                                        AS [Delta Total Worker Time],
-                               ISNULL((( [qrs].[total_worker_time] - [cte].[total_worker_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )       AS [Avg. Worker Time],
-                               ( [qrs].[total_physical_reads] - [cte].[total_physical_reads] )                                                                                  AS [Delta Total Phys Reads],
-                               ISNULL((( [qrs].[total_physical_reads] - [cte].[total_physical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Phys reads],
-                               ( [qrs].[total_logical_reads] - [cte].[total_logical_reads] )                                                                                    AS [Delta Total Log Reads],
-                               ISNULL((( [qrs].[total_logical_reads] - [cte].[total_logical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )   AS [Avg. Log reads],
-                               ( [qrs].[total_logical_writes] - [cte].[total_logical_writes] )                                                                                  AS [Delta Total Log Writes],
-                               ISNULL((( [qrs].[total_logical_writes] - [cte].[total_logical_writes] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Log writes]
-                        INTO   [#OQS_Runtime_Stats]
-                        FROM   [CTE_Update_Runtime_Stats]             AS [cte]
-                               INNER JOIN [oqs].[query_runtime_stats] AS [qrs] ON [cte].[query_id] = [qrs].[query_id]
-                        WHERE  [qrs].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
+                            WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                            DELETE FROM [oqs].[queries]
+                            WHERE [plan_id] IN (   SELECT [p].[plan_id]
+                                                   FROM   [oqs].[plans]                                   AS [p]
+                                                          CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
+                                                   WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 )
 
-                        SET @log_runtime_stats = @@RowCount;
+                            -- Remove all the plans that are related to OQS plans
+                            ;
+                            WITH XMLNAMESPACES ( DEFAULT 'http://schemas.microsoft.com/sqlserver/2004/07/showplan' )
+                            DELETE FROM [oqs].[plans]
+                            WHERE [plan_id] IN (   SELECT [p].[plan_id]
+                                                   FROM   [oqs].[plans]                                   AS [p]
+                                                          CROSS APPLY [plan_executionplan].[nodes]( '.' ) AS [Exec_Plans]([Plans])
+                                                   WHERE  [Exec_Plans].[Plans].[exist]( '//ColumnReference[@Schema = "[oqs]"]' ) = 1 );
 
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_runtime_stats ) + ' runtime statistics...' );
-                            END;
 
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of runtime statistics deltas';
-                                SELECT * FROM [#OQS_Runtime_Stats];
-                            END;
+                            -- Grab the interval_id of the interval we added at the beginning
+                            DECLARE @Interval_ID int;
+                            SET @Interval_ID = IDENT_CURRENT( '[oqs].[intervals]' );
 
-                        -- Update the runtime statistics of the queries captured in the previous interval
-                        -- with the delta runtime information
-                        UPDATE [qrs]
-                        SET    [qrs].[execution_count] = [tqrs].[Delta Exec Count],
-                               [qrs].[total_elapsed_time] = [tqrs].[Delta Time],
-                               [qrs].[avg_elapsed_time] = [tqrs].[Avg. Time],
-                               [qrs].[total_rows] = [tqrs].[Delta Total Rows],
-                               [qrs].[avg_rows] = [tqrs].[Avg. Rows],
-                               [qrs].[total_worker_time] = [tqrs].[Delta Total Worker Time],
-                               [qrs].[avg_worker_time] = [tqrs].[Avg. Worker Time],
-                               [qrs].[total_physical_reads] = [tqrs].[Delta Total Phys Reads],
-                               [qrs].[avg_physical_reads] = [tqrs].[Avg. Phys reads],
-                               [qrs].[total_logical_reads] = [tqrs].[Delta Total Log Reads],
-                               [qrs].[avg_logical_reads] = [tqrs].[Avg. Log reads],
-                               [qrs].[total_logical_writes] = [tqrs].[Delta Total Log Writes],
-                               [qrs].[avg_logical_writes] = [tqrs].[Avg. Log writes]
-                        FROM   [oqs].[query_runtime_stats]     AS [qrs]
-                               INNER JOIN [#OQS_Runtime_Stats] AS [tqrs] ON (   [qrs].[interval_id] = [tqrs].[interval_id]
-                                                                                AND [qrs].[query_id] = [tqrs].[query_id] );
+                            -- Query Runtime Snapshot
 
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of runtime statistics after delta update';
-                                SELECT * FROM [oqs].[query_runtime_stats] AS [qrs];
-                            END;
+                            -- Insert runtime statistics for every query statement that is recorded inside the OQS
+                            INSERT INTO [oqs].[query_runtime_stats] ( [query_id],
+                                                                      [interval_id],
+                                                                      [creation_time],
+                                                                      [last_execution_time],
+                                                                      [execution_count],
+                                                                      [total_elapsed_time],
+                                                                      [last_elapsed_time],
+                                                                      [min_elapsed_time],
+                                                                      [max_elapsed_time],
+                                                                      [avg_elapsed_time],
+                                                                      [total_rows],
+                                                                      [last_rows],
+                                                                      [min_rows],
+                                                                      [max_rows],
+                                                                      [avg_rows],
+                                                                      [total_worker_time],
+                                                                      [last_worker_time],
+                                                                      [min_worker_time],
+                                                                      [max_worker_time],
+                                                                      [avg_worker_time],
+                                                                      [total_physical_reads],
+                                                                      [last_physical_reads],
+                                                                      [min_physical_reads],
+                                                                      [max_physical_reads],
+                                                                      [avg_physical_reads],
+                                                                      [total_logical_reads],
+                                                                      [last_logical_reads],
+                                                                      [min_logical_reads],
+                                                                      [max_logical_reads],
+                                                                      [avg_logical_reads],
+                                                                      [total_logical_writes],
+                                                                      [last_logical_writes],
+                                                                      [min_logical_writes],
+                                                                      [max_logical_writes],
+                                                                      [avg_logical_writes] )
+                                        SELECT [oqs_q].[query_id],
+                                               @Interval_ID,
+                                               MIN([qs].[creation_time]),
+                                               MAX([qs].[last_execution_time]),
+                                               SUM([qs].[execution_count]),
+                                               SUM([qs].[total_elapsed_time]),
+                                               SUM([qs].[last_elapsed_time]),
+                                               MIN([qs].[min_elapsed_time]),
+                                               MAX([qs].[max_elapsed_time]),
+                                               0,
+                                               SUM([qs].[total_rows]),
+                                               SUM([qs].[last_rows]),
+                                               MIN([qs].[min_rows]),
+                                               MAX([qs].[max_rows]),
+                                               0,
+                                               SUM([qs].[total_worker_time]),
+                                               SUM([qs].[last_worker_time]),
+                                               MIN([qs].[min_worker_time]),
+                                               MAX([qs].[max_worker_time]),
+                                               0,
+                                               SUM([qs].[total_physical_reads]),
+                                               SUM([qs].[last_physical_reads]),
+                                               MIN([qs].[min_physical_reads]),
+                                               MAX([qs].[max_physical_reads]),
+                                               0,
+                                               SUM([qs].[total_logical_reads]),
+                                               SUM([qs].[last_logical_reads]),
+                                               MIN([qs].[min_logical_reads]),
+                                               MAX([qs].[max_logical_reads]),
+                                               0,
+                                               SUM([qs].[total_logical_writes]),
+                                               SUM([qs].[last_logical_writes]),
+                                               MIN([qs].[min_logical_writes]),
+                                               MAX([qs].[max_logical_writes]),
+                                               0
+                                        FROM   [oqs].[queries]                AS [oqs_q]
+                                               INNER JOIN [oqs].[query_stats] AS [qs] ON (   [oqs_q].[query_hash] = [qs].[query_hash]
+                                                                                             AND [oqs_q].[query_statement_start_offset] = [qs].[statement_start_offset]
+                                                                                             AND [oqs_q].[query_statement_end_offset] = [qs].[statement_end_offset]
+                                                                                             AND [oqs_q].[query_creation_time] = [qs].[creation_time] )
+                                        GROUP BY [oqs_q].[query_id];
 
-                            -- Calculate Deltas for Wait stats
-						;
-                        WITH [CTE_Update_wait_Stats] ( [interval_id], [wait_type], [waiting_tasks_count], [wait_time_ms], [max_wait_time_ms], [signal_wait_time_ms] )
-                            AS ( SELECT [WS].[interval_id],
-                                        [WS].[wait_type],
-                                        [WS].[waiting_tasks_count],
-                                        [WS].[wait_time_ms],
-                                        [WS].[max_wait_time_ms],
-                                        [WS].[signal_wait_time_ms]
-                                 FROM   [oqs].[wait_stats] AS [WS]
-                                 WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
-                        SELECT [cte].[wait_type],
-                               [cte].[interval_id],
-                               ( [WS].[waiting_tasks_count] - [cte].[waiting_tasks_count] ) AS [Delta Waiting Tasks Count],
-                               ( [WS].[wait_time_ms] - [cte].[wait_time_ms] )               AS [Delta Wait Time ms],
-                               ( [WS].[max_wait_time_ms] - [cte].[max_wait_time_ms] )       AS [Delta Max Wait Time ms],
-                               ( [WS].[signal_wait_time_ms] - [cte].[signal_wait_time_ms] ) AS [Delta Signal Wait Time ms]
-                        INTO   [#OQS_Wait_Stats]
-                        FROM   [CTE_Update_wait_Stats]       AS [cte]
-                               INNER JOIN [oqs].[wait_stats] AS [WS] ON [cte].[wait_type] = [WS].[wait_type]
-                        WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
+                            -- DEBUG: Get current info of the QRS table
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of captured runtime statistics';
+                                    SELECT * FROM [oqs].[query_runtime_stats] AS [QRS];
+                                END;
 
-                        SET @log_wait_stats = @@RowCount;
+                            -- Wait stats snapshot
+                            INSERT INTO [oqs].[wait_stats] ( [interval_id],
+                                                             [wait_type],
+                                                             [waiting_tasks_count],
+                                                             [wait_time_ms],
+                                                             [max_wait_time_ms],
+                                                             [signal_wait_time_ms] )
+                                        SELECT @Interval_ID,
+                                               [wait_type],
+                                               [waiting_tasks_count],
+                                               [wait_time_ms],
+                                               [max_wait_time_ms],
+                                               [signal_wait_time_ms]
+                                        FROM   [sys].[dm_os_wait_stats]
+                                        WHERE  (   [waiting_tasks_count] > 0
+                                                   AND [wait_time_ms] > 0 );
 
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_wait_stats ) + ' wait statistics...' );
-                            END;
+                            -- DEBUG: Get current info of the wait stats table
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of wait stats';
+                                    SELECT * FROM [oqs].[wait_stats] AS [WS];
+                                END;
 
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of wait stats deltas';
-                                SELECT * FROM [#OQS_Wait_Stats];
-                            END;
+                            -- Close the previous interval now that the statistics are updated
+                            UPDATE [oqs].[intervals]
+                            SET    [interval_end] = GETDATE()
+                            WHERE  [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] );
 
-                        -- Update the runtime statistics of the queries captured in the previous interval
-                        -- with the delta runtime information
-                        UPDATE [WS]
-                        SET    [WS].[waiting_tasks_count] = [tws].[Delta Waiting Tasks Count],
-                               [WS].[wait_time_ms] = [Delta Wait Time ms],
-                               [WS].[max_wait_time_ms] = [Delta Max Wait Time ms],
-                               [WS].[signal_wait_time_ms] = [Delta Signal Wait Time ms]
-                        FROM   [oqs].[wait_stats]           AS [WS]
-                               INNER JOIN [#OQS_Wait_Stats] AS [tws] ON (   [WS].[interval_id] = [tws].[interval_id]
-                                                                            AND [WS].[wait_type] = [tws].[wait_type] );
+                            -- Now that we have the runtime statistics inside the OQS we need to perform some calculations
+                            -- so we can see query performance per interval captured
 
-                        IF @debug = 1
-                            BEGIN
-                                SELECT 'Snapshot of runtime statistics after delta update';
-                                SELECT * FROM [oqs].[wait_stats] AS [WS];
-                            END;
+                            -- First thing we need is a temporary table to hold our calculated deltas
+                            IF OBJECT_ID( 'tempdb..#OQS_Runtime_Stats' ) IS NOT NULL
+                                BEGIN
+                                    DROP TABLE [#OQS_Runtime_Stats];
+                                END;
 
-                        -- Remove the wait stats delta's where 0 waits occured
-                        DELETE FROM [oqs].[wait_stats]
-                        WHERE (   [waiting_tasks_count] = 0
-                                  AND [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ));
+                            IF OBJECT_ID( 'tempdb..#OQS_Wait_Stats' ) IS NOT NULL
+                                BEGIN
+                                    DROP TABLE [#OQS_Wait_Stats];
+                                END
 
-                        -- Run regular OQS store cleanup if activated
-                        IF @data_cleanup_active = 1
-                            BEGIN
-                                IF @logmode = 1
-                                    BEGIN
-                                        INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                           [log_timestamp],
-                                                                           [log_message] )
-                                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
-                                    END;
+                                -- Calculate Deltas for Runtime stats
+                                ;
+                            WITH [CTE_Update_Runtime_Stats] ( [query_id], [interval_id], [execution_count], [total_elapsed_time], [total_rows], [total_worker_time], [total_physical_reads], [total_logical_reads], [total_logical_writes] )
+                            AS ( SELECT [QRS].[query_id],
+                                        [QRS].[interval_id],
+                                        [QRS].[execution_count],
+                                        [QRS].[total_elapsed_time],
+                                        [QRS].[total_rows],
+                                        [QRS].[total_worker_time],
+                                        [QRS].[total_physical_reads],
+                                        [QRS].[total_logical_reads],
+                                        [QRS].[total_logical_writes]
+                                 FROM   [oqs].[query_runtime_stats] AS [QRS]
+                                 WHERE  [QRS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
+                            SELECT [cte].[query_id],
+                                   [cte].[interval_id],
+                                   ( [qrs].[execution_count] - [cte].[execution_count] )                                                                                            AS [Delta Exec Count],
+                                   ( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] )                                                                                      AS [Delta Time],
+                                   ISNULL((( [qrs].[total_elapsed_time] - [cte].[total_elapsed_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )     AS [Avg. Time],
+                                   ( [qrs].[total_rows] - [cte].[total_rows] )                                                                                                      AS [Delta Total Rows],
+                                   ISNULL((( [qrs].[total_rows] - [cte].[total_rows] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )                     AS [Avg. Rows],
+                                   ( [qrs].[total_worker_time] - [cte].[total_worker_time] )                                                                                        AS [Delta Total Worker Time],
+                                   ISNULL((( [qrs].[total_worker_time] - [cte].[total_worker_time] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )       AS [Avg. Worker Time],
+                                   ( [qrs].[total_physical_reads] - [cte].[total_physical_reads] )                                                                                  AS [Delta Total Phys Reads],
+                                   ISNULL((( [qrs].[total_physical_reads] - [cte].[total_physical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Phys reads],
+                                   ( [qrs].[total_logical_reads] - [cte].[total_logical_reads] )                                                                                    AS [Delta Total Log Reads],
+                                   ISNULL((( [qrs].[total_logical_reads] - [cte].[total_logical_reads] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 )   AS [Avg. Log reads],
+                                   ( [qrs].[total_logical_writes] - [cte].[total_logical_writes] )                                                                                  AS [Delta Total Log Writes],
+                                   ISNULL((( [qrs].[total_logical_writes] - [cte].[total_logical_writes] ) / NULLIF(( [qrs].[execution_count] - [cte].[execution_count] ), 0)), 0 ) AS [Avg. Log writes]
+                            INTO   [#OQS_Runtime_Stats]
+                            FROM   [CTE_Update_Runtime_Stats]             AS [cte]
+                                   INNER JOIN [oqs].[query_runtime_stats] AS [qrs] ON [cte].[query_id] = [qrs].[query_id]
+                            WHERE  [qrs].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
 
-								-- Tidy up time!
-                                EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
-                                                          @data_cleanup_throttle = @data_cleanup_throttle;
+                            SET @log_runtime_stats = @@RowCount;
 
-                            END;
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_runtime_stats ) + ' runtime statistics...' );
+                                END;
 
-                        -- And we are done!
-                        IF @logmode = 1
-                            BEGIN
-                                INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                   [log_timestamp],
-                                                                   [log_message] )
-                                VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script finished...' );
-                            END;
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of runtime statistics deltas';
+                                    SELECT * FROM [#OQS_Runtime_Stats];
+                                END;
+
+                            -- Update the runtime statistics of the queries captured in the previous interval
+                            -- with the delta runtime information
+                            UPDATE [qrs]
+                            SET    [qrs].[execution_count] = [tqrs].[Delta Exec Count],
+                                   [qrs].[total_elapsed_time] = [tqrs].[Delta Time],
+                                   [qrs].[avg_elapsed_time] = [tqrs].[Avg. Time],
+                                   [qrs].[total_rows] = [tqrs].[Delta Total Rows],
+                                   [qrs].[avg_rows] = [tqrs].[Avg. Rows],
+                                   [qrs].[total_worker_time] = [tqrs].[Delta Total Worker Time],
+                                   [qrs].[avg_worker_time] = [tqrs].[Avg. Worker Time],
+                                   [qrs].[total_physical_reads] = [tqrs].[Delta Total Phys Reads],
+                                   [qrs].[avg_physical_reads] = [tqrs].[Avg. Phys reads],
+                                   [qrs].[total_logical_reads] = [tqrs].[Delta Total Log Reads],
+                                   [qrs].[avg_logical_reads] = [tqrs].[Avg. Log reads],
+                                   [qrs].[total_logical_writes] = [tqrs].[Delta Total Log Writes],
+                                   [qrs].[avg_logical_writes] = [tqrs].[Avg. Log writes]
+                            FROM   [oqs].[query_runtime_stats]     AS [qrs]
+                                   INNER JOIN [#OQS_Runtime_Stats] AS [tqrs] ON (   [qrs].[interval_id] = [tqrs].[interval_id]
+                                                                                    AND [qrs].[query_id] = [tqrs].[query_id] );
+
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of runtime statistics after delta update';
+                                    SELECT * FROM [oqs].[query_runtime_stats] AS [qrs];
+                                END;
+
+                                -- Calculate Deltas for Wait stats
+						    ;
+                            WITH [CTE_Update_wait_Stats] ( [interval_id], [wait_type], [waiting_tasks_count], [wait_time_ms], [max_wait_time_ms], [signal_wait_time_ms] )
+                                AS ( SELECT [WS].[interval_id],
+                                            [WS].[wait_type],
+                                            [WS].[waiting_tasks_count],
+                                            [WS].[wait_time_ms],
+                                            [WS].[max_wait_time_ms],
+                                            [WS].[signal_wait_time_ms]
+                                     FROM   [oqs].[wait_stats] AS [WS]
+                                     WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ))
+                            SELECT [cte].[wait_type],
+                                   [cte].[interval_id],
+                                   ( [WS].[waiting_tasks_count] - [cte].[waiting_tasks_count] ) AS [Delta Waiting Tasks Count],
+                                   ( [WS].[wait_time_ms] - [cte].[wait_time_ms] )               AS [Delta Wait Time ms],
+                                   ( [WS].[max_wait_time_ms] - [cte].[max_wait_time_ms] )       AS [Delta Max Wait Time ms],
+                                   ( [WS].[signal_wait_time_ms] - [cte].[signal_wait_time_ms] ) AS [Delta Signal Wait Time ms]
+                            INTO   [#OQS_Wait_Stats]
+                            FROM   [CTE_Update_wait_Stats]       AS [cte]
+                                   INNER JOIN [oqs].[wait_stats] AS [WS] ON [cte].[wait_type] = [WS].[wait_type]
+                            WHERE  [WS].[interval_id] = ( SELECT MAX( [interval_id] ) FROM [oqs].[intervals] );
+
+                            SET @log_wait_stats = @@RowCount;
+
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore captured ' + CONVERT( varchar, @log_wait_stats ) + ' wait statistics...' );
+                                END;
+
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of wait stats deltas';
+                                    SELECT * FROM [#OQS_Wait_Stats];
+                                END;
+
+                            -- Update the runtime statistics of the queries captured in the previous interval
+                            -- with the delta runtime information
+                            UPDATE [WS]
+                            SET    [WS].[waiting_tasks_count] = [tws].[Delta Waiting Tasks Count],
+                                   [WS].[wait_time_ms] = [Delta Wait Time ms],
+                                   [WS].[max_wait_time_ms] = [Delta Max Wait Time ms],
+                                   [WS].[signal_wait_time_ms] = [Delta Signal Wait Time ms]
+                            FROM   [oqs].[wait_stats]           AS [WS]
+                                   INNER JOIN [#OQS_Wait_Stats] AS [tws] ON (   [WS].[interval_id] = [tws].[interval_id]
+                                                                                AND [WS].[wait_type] = [tws].[wait_type] );
+
+                            IF @debug = 1
+                                BEGIN
+                                    SELECT 'Snapshot of runtime statistics after delta update';
+                                    SELECT * FROM [oqs].[wait_stats] AS [WS];
+                                END;
+
+                            -- Remove the wait stats delta's where 0 waits occured
+                            DELETE FROM [oqs].[wait_stats]
+                            WHERE (   [waiting_tasks_count] = 0
+                                      AND [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ));
+
+                            -- Run regular OQS store cleanup if activated
+                            IF @data_cleanup_active = 1
+                                BEGIN
+                                    IF @logmode = 1
+                                        BEGIN
+                                            INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                               [log_timestamp],
+                                                                               [log_message] )
+                                            VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
+                                        END;
+
+								    -- Tidy up time!
+                                    EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
+                                                              @data_cleanup_throttle = @data_cleanup_throttle;
+
+                                END;
+
+                            -- And we are done!
+                            IF @logmode = 1
+                                BEGIN
+                                    INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                                       [log_timestamp],
+                                                                       [log_message] )
+                                    VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore capture script finished...' );
+                                END;
+                        END;
+                    END
+                ELSE
+                    BEGIN
+                        SET @log_logrunid = (   SELECT ISNULL( MAX( [AL].[log_run_id] ), 0 ) + 1
+                                                FROM   [oqs].[activity_log] AS [AL] );
+
+                        INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                           [log_timestamp],
+                                                           [log_message] )
+                        VALUES ( @log_logrunid, GETDATE(), 'The OpenQueryStore data store is full. Current configured maximum size (MB): '+CAST(@oqs_maximum_size_mb AS varchar(5)));
                     END;
             END;
         ELSE

--- a/setup/install_gather_statistics.sql
+++ b/setup/install_gather_statistics.sql
@@ -570,23 +570,6 @@ AS
                             WHERE (   [waiting_tasks_count] = 0
                                       AND [interval_id] = ( SELECT MAX( [interval_id] ) - 1 FROM [oqs].[intervals] ));
 
-                            -- Run regular OQS store cleanup if activated
-                            IF @data_cleanup_active = 1
-                                BEGIN
-                                    IF @logmode = 1
-                                        BEGIN
-                                            INSERT INTO [oqs].[activity_log] ( [log_run_id],
-                                                                               [log_timestamp],
-                                                                               [log_message] )
-                                            VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
-                                        END;
-
-								    -- Tidy up time!
-                                    EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
-                                                              @data_cleanup_throttle = @data_cleanup_throttle;
-
-                                END;
-
                             -- And we are done!
                             IF @logmode = 1
                                 BEGIN
@@ -617,5 +600,22 @@ AS
                                                    [log_timestamp],
                                                    [log_message] )
                 VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data capture not activated. Collection skipped' );
+            END;
+
+        -- Run regular OQS store cleanup if activated
+        IF @data_cleanup_active = 1
+            BEGIN
+                IF @logmode = 1
+                    BEGIN
+                        INSERT INTO [oqs].[activity_log] ( [log_run_id],
+                                                            [log_timestamp],
+                                                            [log_message] )
+                        VALUES ( @log_logrunid, GETDATE(), 'OpenQueryStore data cleanup process executed.' );
+                    END;
+
+                -- Tidy up time!
+                EXEC [oqs].[data_cleanup] @data_cleanup_threshold = @data_cleanup_threshold,
+                                            @data_cleanup_throttle = @data_cleanup_throttle;
+
             END;
     END;

--- a/setup/install_open_query_store_base.sql
+++ b/setup/install_open_query_store_base.sql
@@ -49,10 +49,10 @@ CREATE TABLE [oqs].[collection_metadata]
         [oqs_classic_db]         nvarchar (128)  NOT NULL, -- The database where OQS resides in classic mode (must be filled when classic mode is chosen, ignored by centralized mode)
         [collection_active]      bit             NOT NULL, -- Should OQS be collecting data or not
         [execution_threshold]    tinyint         NOT NULL, -- The minimum executions of a query plan before we consider it for capture in OQS
+        [oqs_maximum_size_mb]    smallint        NOT NULL, -- The maximum size in MB that OQS data store should be (actual size can be slightly larger, but this is the "high water mark" to control data collection)
         [data_cleanup_active]    bit             NOT NULL, -- Should OQS automatically clean up old data
         [data_cleanup_threshold] tinyint         NOT NULL, -- How many days should OQS keep data for (automated cleanup removes data older than this)
         [data_cleanup_throttle]  smallint        NOT NULL, -- How many rows can be deleted in one pass. This avoids large deletions from trashing the transaction log and blocking OQS tables.
-
     );
 GO
 
@@ -62,13 +62,14 @@ ADD CONSTRAINT [chk_oqs_mode]           CHECK ( [oqs_mode] IN ( N'classic', N'ce
     CONSTRAINT [df_collection_interval] DEFAULT ( 60 )   FOR [collection_interval],
     CONSTRAINT [df_collection_active]   DEFAULT ( 0 )    FOR [collection_active],
     CONSTRAINT [df_execution_threshold] DEFAULT ( 2 )    FOR [execution_threshold],
+    CONSTRAINT [df_oqs_maximum_size_mb] DEFAULT ( 100 )  FOR [oqs_maximum_size_mb],
     CONSTRAINT [df_cleanup_active]      DEFAULT ( 0 )    FOR [data_cleanup_active],
     CONSTRAINT [df_cleanup_threshold]   DEFAULT ( 30 )   FOR [data_cleanup_threshold],
     CONSTRAINT [df_cleanup_throttle]    DEFAULT ( 5000 ) FOR [data_cleanup_throttle];
 
 
 -- Semi-hidden way of documenting the version of OQS that is installed. The value will be automatically bumped upon a new version build/release
-EXEC sys.sp_addextendedproperty @name=N'oqs_version', @value=N'2.2.0' , @level0type=N'SCHEMA',@level0name=N'oqs', @level1type=N'TABLE',@level1name=N'collection_metadata'
+EXEC sys.sp_addextendedproperty @name=N'oqs_version', @value=N'2.3.0' , @level0type=N'SCHEMA',@level0name=N'oqs', @level1type=N'TABLE',@level1name=N'collection_metadata'
 GO
 
 -- Default values for initial installation = Logging turned on, run every 60 seconds, collection deactivated, execution_threshold = 2 to skip single-use plans
@@ -78,11 +79,12 @@ INSERT INTO [oqs].[collection_metadata] (   [command],
                                             [oqs_classic_db],
                                             [collection_active],
                                             [execution_threshold],
+											[oqs_maximum_size_mb],
                                             [data_cleanup_active],
                                             [data_cleanup_threshold],
                                             [data_cleanup_throttle]
                                         )
-VALUES ( N'EXEC [oqs].[gather_statistics] @logmode=1', DEFAULT , '{OQSMode}','{DatabaseWhereOQSIsRunning}',DEFAULT,DEFAULT,DEFAULT,DEFAULT,DEFAULT);
+VALUES ( N'EXEC [oqs].[gather_statistics] @logmode=1', DEFAULT , '{OQSMode}','{DatabaseWhereOQSIsRunning}',DEFAULT,DEFAULT,DEFAULT,DEFAULT,DEFAULT,DEFAULT);
 GO
 
 CREATE TABLE [oqs].[activity_log]
@@ -563,4 +565,18 @@ AS
 
 
     END;
+GO
+
+CREATE VIEW oqs.object_catalog
+AS
+SELECT o.[name] AS [object_name],
+       o.[object_id] AS [object_id],
+       o.[type] AS [object_type],
+	   ps.row_count,
+	   ( ps.reserved_page_count * 8 ) AS [space_used_kb]
+FROM sys.objects o
+    INNER JOIN sys.schemas s
+        ON o.[schema_id] = s.[schema_id]
+	LEFT JOIN sys.dm_db_partition_stats ps ON ps.object_id = o.object_id AND ps.index_id IN (0,1)
+WHERE s.[name] = 'oqs';
 GO

--- a/setup/install_open_query_store_base.sql
+++ b/setup/install_open_query_store_base.sql
@@ -68,7 +68,7 @@ ADD CONSTRAINT [chk_oqs_mode]           CHECK ( [oqs_mode] IN ( N'classic', N'ce
 
 
 -- Semi-hidden way of documenting the version of OQS that is installed. The value will be automatically bumped upon a new version build/release
-EXEC sys.sp_addextendedproperty @name=N'oqs_version', @value=N'2.1.0' , @level0type=N'SCHEMA',@level0name=N'oqs', @level1type=N'TABLE',@level1name=N'collection_metadata'
+EXEC sys.sp_addextendedproperty @name=N'oqs_version', @value=N'2.2.0' , @level0type=N'SCHEMA',@level0name=N'oqs', @level1type=N'TABLE',@level1name=N'collection_metadata'
 GO
 
 -- Default values for initial installation = Logging turned on, run every 60 seconds, collection deactivated, execution_threshold = 2 to skip single-use plans

--- a/setup/install_service_broker.sql
+++ b/setup/install_service_broker.sql
@@ -38,7 +38,7 @@ GO
 -- Enable the Service Broker for the user database
 DECLARE @db sysname;
 
-SET @db = DB_NAME();
+SET @db = QUOTENAME(DB_NAME());
 
 IF  (   SELECT [is_broker_enabled]
         FROM   [sys].[databases]
@@ -165,7 +165,7 @@ AS
     -- The procedure is called at every SQL Server startup
     BEGIN
         SET NOCOUNT ON;
-        EXEC {DatabaseWhereOQSIsRunning}.[oqs].[start_scheduler];
+        EXEC [{DatabaseWhereOQSIsRunning}].[oqs].[start_scheduler];
     END;
 GO
 

--- a/setup/uninstall_open_query_store.sql
+++ b/setup/uninstall_open_query_store.sql
@@ -194,6 +194,14 @@ IF EXISTS (   SELECT *
     END;
 
 IF EXISTS (   SELECT *
+              FROM   [sys].[views] AS [V]
+              WHERE  [V].[object_id] = OBJECT_ID( N'[oqs].[object_catalog]' )
+          )
+    BEGIN
+        DROP VIEW [oqs].[object_catalog];
+    END;    
+
+IF EXISTS (   SELECT *
               FROM   [sys].[server_principals] AS [SP]
               WHERE  [SP].[name] = 'open_query_store'
           )


### PR DESCRIPTION
When installing OQS (version 2.3.1) on a second database, the startup procedure 'open_query_store_startup' already exists and install_service_broker.sql will return an error, telling the procedure already exists.

Changed code (will check for the procedure, using a create or alter statement):
USE [master];
 GO

SET ANSI_NULLS ON;
 GO

SET QUOTED_IDENTIFIER ON;
 GO

IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME = 'open_query_store_startup')
 EXEC ('CREATE PROC dbo.open_query_store_startup AS SELECT ''stub version, to be replaced''')
 GO

ALTER PROCEDURE [dbo].[open_query_store_startup]
AS
...