### PR TITLE
Update install_service_broker.sql

### DIFF
--- a/setup/install_service_broker.sql
+++ b/setup/install_service_broker.sql
@@ -157,9 +157,13 @@ SET ANSI_NULLS ON;
 GO
 
 SET QUOTED_IDENTIFIER ON;
-GO
+GO		    		    
 
-CREATE PROCEDURE [dbo].[open_query_store_startup]
+IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.ROUTINES WHERE ROUTINE_NAME = 'open_query_store_startup')
+    EXEC ('CREATE PROC dbo.open_query_store_startup AS SELECT ''stub version, to be replaced''')
+GO
+		    
+ALTER PROCEDURE [dbo].[open_query_store_startup]
 AS
     -- This stored procedure is used to activate Open Query Store data collection using Service Broker
     -- The procedure is called at every SQL Server startup


### PR DESCRIPTION
If OQS is installed on a second database within the same instance, the procedure dbo.open_query_store_startup is already present, so the create statement will fail, which will lead to the uninstallation of OQS.
Now the script will check if the procedure is already present, and if not, it will create an empty procedure, which can be altered to include the body, on the same way as Adam Machanic does with sp_whoisactive.